### PR TITLE
Add MIT License

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,13 @@
     <version>${revision}${changelist}</version>
     <name>Text Finder</name>
     <url>https://wiki.jenkins.io/display/JENKINS/Text-finder+Plugin</url>
+    <licenses>
+     <license>
+       <name>The MIT License (MIT)</name>
+       <url>http://opensource.org/licenses/MIT</url>
+       <distribution>repo</distribution>
+     </license>
+   </licenses>
     <properties>
         <revision>1.13</revision>
         <changelist>-SNAPSHOT</changelist>


### PR DESCRIPTION
Thanks for your work on this plugin. We really appreciate your efforts at Swrve, but we've been unable to track down which license your plugin false under. I would have preferred to simply open an issue about this, but your repo doesn't seem to accept issues :cry:, hence this pull request. I've added the MIT license in this PR, as it seems to be used quite frequently by Jenkins plugins, although you can of course choose whichever license you like.
