### PR TITLE
Multiple finders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target/
 /work/
+.idea/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   
   <artifactId>text-finder</artifactId>
   <packaging>hpi</packaging>
-  <version>1.11-SNAPSHOT</version>
+  <version>1.10.1</version>
   <name>Jenkins TextFinder plugin</name>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Text-finder+Plugin</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <artifactId>text-finder</artifactId>
     <packaging>hpi</packaging>
-    <version>1.10.2</version>
+    <version>1.11-SNAPSHOT</version>
     <name>Jenkins TextFinder plugin</name>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Text-finder+Plugin</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,70 +1,59 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>1.645</version>
-    </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>1.480</version>
+  </parent>
 
-    <artifactId>text-finder</artifactId>
-    <packaging>hpi</packaging>
-    <version>1.11-SNAPSHOT</version>
-    <name>Jenkins TextFinder plugin</name>
-    <url>http://wiki.jenkins-ci.org/display/JENKINS/Text-finder+Plugin</url>
+  <artifactId>text-finder</artifactId>
+  <packaging>hpi</packaging>
+  <version>1.11-SNAPSHOT</version>
+  <name>Jenkins TextFinder plugin</name>
+  <url>http://wiki.jenkins-ci.org/display/JENKINS/Text-finder+Plugin</url>
 
-    <developers>
-        <developer>
-            <id>kohsuke</id>
-            <name>Kohsuke Kawaguchi</name>
-        </developer>
-        <developer>
-            <name>Santiago Pericas-Geertsen</name>
-        </developer>
-    </developers>
-    <scm>
-        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    </scm>
+  <developers>
+    <developer>
+      <id>kohsuke</id>
+      <name>Kohsuke Kawaguchi</name>
+    </developer>
+    <developer>
+      <name>Santiago Pericas-Geertsen</name>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+  </scm>
 
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-war</artifactId>
-            <type>war</type>
-            <version>1.645</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-
-</project>  
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+</project>
   
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,27 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.jenkins-ci.plugins</groupId>
-    <artifactId>plugin</artifactId>
-    <version>1.480</version>
-  </parent>
-  
-  <artifactId>text-finder</artifactId>
-  <packaging>hpi</packaging>
-  <version>1.10.1</version>
-  <name>Jenkins TextFinder plugin</name>
-  <url>http://wiki.jenkins-ci.org/display/JENKINS/Text-finder+Plugin</url>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>1.645</version>
+    </parent>
 
-  <developers>
-    <developer>
-      <id>kohsuke</id>
-      <name>Kohsuke Kawaguchi</name>
-    </developer>
-    <developer>
-      <name>Santiago Pericas-Geertsen</name>
-    </developer>
-  </developers>
+    <artifactId>text-finder</artifactId>
+    <packaging>hpi</packaging>
+    <version>1.10.2</version>
+    <name>Jenkins TextFinder plugin</name>
+    <url>http://wiki.jenkins-ci.org/display/JENKINS/Text-finder+Plugin</url>
+
+    <developers>
+        <developer>
+            <id>kohsuke</id>
+            <name>Kohsuke Kawaguchi</name>
+        </developer>
+        <developer>
+            <name>Santiago Pericas-Geertsen</name>
+        </developer>
+    </developers>
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
@@ -41,6 +54,17 @@
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>jenkins-war</artifactId>
+            <type>war</type>
+            <version>1.645</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
 </project>  
   
 

--- a/src/main/java/hudson/plugins/textfinder/TextFinderModel.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderModel.java
@@ -25,7 +25,7 @@ public final class TextFinderModel extends AbstractDescribableImpl<TextFinderMod
 
     @DataBoundConstructor
     public TextFinderModel(String fileSet, String regexp, boolean succeedIfFound, boolean unstableIfFound, boolean alsoCheckConsoleOutput, boolean notBuiltIfFound) {
-        this.fileSet = Util.fixEmpty(fileSet.trim());
+        this.fileSet = fileSet != null ? Util.fixEmpty(fileSet.trim()) : null;
         this.regexp = regexp;
         this.succeedIfFound = succeedIfFound;
         this.unstableIfFound = unstableIfFound;

--- a/src/main/java/hudson/plugins/textfinder/TextFinderModel.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderModel.java
@@ -1,0 +1,74 @@
+package hudson.plugins.textfinder;
+
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.Serializable;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+public final class TextFinderModel extends AbstractDescribableImpl<TextFinderModel> implements Serializable {
+    private static final long serialVersionUID = 7645849785536280615L;
+
+    public final String fileSet;
+    public final String regexp;
+    public final boolean succeedIfFound;
+    public final boolean unstableIfFound;
+    public final boolean notBuiltIfFound;
+    /**
+     * True to also scan the whole console output
+     */
+    public final boolean alsoCheckConsoleOutput;
+
+    @DataBoundConstructor
+    public TextFinderModel(String fileSet, String regexp, boolean succeedIfFound, boolean unstableIfFound, boolean alsoCheckConsoleOutput, boolean notBuiltIfFound) {
+        this.fileSet = Util.fixEmpty(fileSet.trim());
+        this.regexp = regexp;
+        this.succeedIfFound = succeedIfFound;
+        this.unstableIfFound = unstableIfFound;
+        this.alsoCheckConsoleOutput = alsoCheckConsoleOutput;
+        this.notBuiltIfFound = notBuiltIfFound;
+
+        // Attempt to compile regular expression
+        try {
+            Pattern.compile(regexp);
+        } catch (PatternSyntaxException e) {
+            // falls through
+        }
+    }
+
+    public String getFileSet() {
+        return fileSet;
+    }
+
+    public String getRegexp() {
+        return regexp;
+    }
+
+    public boolean isSucceedIfFound() {
+        return succeedIfFound;
+    }
+
+    public boolean isUnstableIfFound() {
+        return unstableIfFound;
+    }
+
+    public boolean isNotBuiltIfFound() {
+        return notBuiltIfFound;
+    }
+
+    public boolean isAlsoCheckConsoleOutput() {
+        return alsoCheckConsoleOutput;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<TextFinderModel> {
+        @Override
+        public String getDisplayName() {
+            return "Text finder";
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
@@ -45,18 +45,20 @@ public class TextFinderPublisher extends Recorder implements Serializable {
     public final String regexp;
     public final boolean succeedIfFound;
     public final boolean unstableIfFound;
+    public final boolean notBuiltIfFound;
     /**
      * True to also scan the whole console output
      */
     public final boolean alsoCheckConsoleOutput;
 
     @DataBoundConstructor
-    public TextFinderPublisher(String fileSet, String regexp, boolean succeedIfFound, boolean unstableIfFound, boolean alsoCheckConsoleOutput) {
+    public TextFinderPublisher(String fileSet, String regexp, boolean succeedIfFound, boolean unstableIfFound, boolean alsoCheckConsoleOutput, boolean notBuiltIfFound) {
         this.fileSet = Util.fixEmpty(fileSet.trim());
         this.regexp = regexp;
         this.succeedIfFound = succeedIfFound;
         this.unstableIfFound = unstableIfFound;
         this.alsoCheckConsoleOutput = alsoCheckConsoleOutput;
+        this.notBuiltIfFound = notBuiltIfFound;
         
         // Attempt to compile regular expression
         try {
@@ -144,8 +146,15 @@ public class TextFinderPublisher extends Recorder implements Serializable {
                 });
             }
 
-            if (foundText != succeedIfFound)
-                build.setResult(unstableIfFound ? Result.UNSTABLE : Result.FAILURE);
+            if (foundText != succeedIfFound) {
+                final Result finalResult;
+                if (notBuiltIfFound) {
+                    finalResult = Result.NOT_BUILT;
+                } else {
+                    finalResult = unstableIfFound ? Result.UNSTABLE : Result.FAILURE;
+                }
+                build.setResult(finalResult);
+            }
         } catch (AbortException e) {
             // no test file found
             build.setResult(Result.UNSTABLE);

--- a/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
@@ -3,6 +3,7 @@ package hudson.plugins.textfinder;
 import hudson.Extension;
 import hudson.FilePath.FileCallable;
 import hudson.Launcher;
+import hudson.Util;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
@@ -59,7 +60,7 @@ public class TextFinderPublisher extends Recorder implements Serializable {
                                boolean alsoCheckConsoleOutput, boolean notBuiltIfFound, List<TextFinderModel>
                                        textFinders) {
         this.textFinders = textFinders;
-        this.fileSet = fileSet;
+        this.fileSet = fileSet != null ? Util.fixEmpty(fileSet.trim()) : null;
         this.regexp = regexp;
         this.succeedIfFound = succeedIfFound;
         this.unstableIfFound = unstableIfFound;

--- a/src/main/resources/hudson/plugins/textfinder/TextFinderModel/config.jelly
+++ b/src/main/resources/hudson/plugins/textfinder/TextFinderModel/config.jelly
@@ -1,6 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:entry field="fileSet" title="${%Files}">
         <f:textbox/>
     </f:entry>
@@ -19,13 +18,5 @@
     </f:entry>
     <f:entry field="notBuiltIfFound" title="${%Not Built if found}">
         <f:checkbox/>
-    </f:entry>
-    <f:entry field="textFinders">
-        <f:hetero-list name="textFinders"
-                       hasHeader="true"
-                       descriptors="${descriptor.itemDescriptors}"
-                       items="${instance.textFinders}"
-                       addCaption="Add Text finder"
-                       deleteCaption="Delete Text finder"/>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/textfinder/TextFinderPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/textfinder/TextFinderPublisher/config.jelly
@@ -15,4 +15,7 @@
   <f:entry field="unstableIfFound" title="${%Unstable if found}">
     <f:checkbox/>
   </f:entry>
+  <f:entry field="notBuiltIfFound" title="${%Not Built if found}">
+    <f:checkbox/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/textfinder/TextFinderPublisher/help-notBuiltIfFound.html
+++ b/src/main/resources/hudson/plugins/textfinder/TextFinderPublisher/help-notBuiltIfFound.html
@@ -1,0 +1,3 @@
+<div>
+    Use this option to set build as Not Built.
+</div>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
   This plugin is used to search for strings in workspace files. The outcome
   of this search can be used to mark the build as normal or failed.


### PR DESCRIPTION
This adds posibility to set multiple text finders to one build. Last wins.
It's done in backward compatible way, so unfortunately all fields must stay in `Publisher`, I added just List of another instances.

#8 is needed for this PR, so please review it first.