### PR TITLE
[JENKINS-34983] - Add pipeline support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+buildPlugin()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPlugin(jenkinsVersions: [null, '2.121.1'])

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <name>Jenkins TextFinder plugin</name>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Text-finder+Plugin</url>
   <properties>
-    <jenkins.version>1.650</jenkins.version>
+    <jenkins.version>1.651</jenkins.version>
     <java.level>7</java.level>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,8 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.480</version>
+    <version>3.4</version>
+    <relativePath />
   </parent>
   
   <artifactId>text-finder</artifactId>
@@ -12,6 +13,10 @@
   <version>1.11-SNAPSHOT</version>
   <name>Jenkins TextFinder plugin</name>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Text-finder+Plugin</url>
+  <properties>
+    <jenkins.version>1.642.1</jenkins.version>
+    <java.level>7</java.level>
+  </properties>
 
   <developers>
     <developer>
@@ -28,17 +33,49 @@
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     </scm>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-basic-steps</artifactId>
+            <version>2.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <version>2.10</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <version>2.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>2.4</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
 </project>  

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <name>Jenkins TextFinder plugin</name>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Text-finder+Plugin</url>
   <properties>
-    <jenkins.version>1.642.1</jenkins.version>
+    <jenkins.version>1.651</jenkins.version>
     <java.level>7</java.level>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <name>Jenkins TextFinder plugin</name>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Text-finder+Plugin</url>
   <properties>
-    <jenkins.version>1.651</jenkins.version>
+    <jenkins.version>1.650</jenkins.version>
     <java.level>7</java.level>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.4</version>
+    <version>3.15</version>
     <relativePath />
   </parent>
   

--- a/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
@@ -215,7 +215,7 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
         return pattern;
     }
 
-    @Symbol("textFinder")
+    @Symbol("findText")
     @Extension
     public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
         @Override

--- a/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
@@ -29,8 +29,9 @@ import org.kohsuke.stapler.QueryParameter;
 import javax.servlet.ServletException;
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.io.Serializable;
 import java.util.regex.Matcher;
@@ -183,7 +184,7 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
         try {
             // Assume default encoding and text files
             String line;
-            reader = new BufferedReader(new FileReader(f));
+            reader = new BufferedReader(new InputStreamReader(new FileInputStream(f), "UTF-8"));
             while ((line = reader.readLine()) != null) {
                 Matcher matcher = pattern.matcher(line);
                 if (matcher.find()) {
@@ -223,7 +224,7 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
     public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
         @Override
         public String getDisplayName() {
-            return Messages.DisplayName();
+            return Messages.TextFinderPublisher_DisplayName();
         }
 
         @Override
@@ -267,7 +268,7 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
 
         @Override
         public Boolean invoke(File ws, VirtualChannel channel) throws IOException {
-            PrintStream logger = new PrintStream(ros);
+            PrintStream logger = new PrintStream(ros, false, "UTF-8");
 
             // Collect list of files for searching
             FileSet fs = new FileSet();

--- a/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
@@ -81,21 +81,9 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
         this.alsoCheckConsoleOutput = alsoCheckConsoleOutput;
     }
 
-    public String getRegexp() {
-        return regexp;
-    }
-
-    public String getFileSet() {
-        return fileSet;
-    }
-
     @DataBoundSetter
     public void setFileSet(String fileSet) {
         this.fileSet = Util.fixEmpty(fileSet.trim());
-    }
-
-    public boolean isSucceedIfFound() {
-        return succeedIfFound;
     }
 
     @DataBoundSetter
@@ -103,17 +91,9 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
         this.succeedIfFound = succeedIfFound;
     }
 
-    public boolean isUnstableIfFound() {
-        return unstableIfFound;
-    }
-
     @DataBoundSetter
     public void setUnstableIfFound(boolean unstableIfFound) {
         this.unstableIfFound = unstableIfFound;
-    }
-
-    public boolean isAlsoCheckConsoleOutput() {
-        return alsoCheckConsoleOutput;
     }
 
     @DataBoundSetter

--- a/src/main/resources/hudson/plugins/textfinder/Messages.properties
+++ b/src/main/resources/hudson/plugins/textfinder/Messages.properties
@@ -1,1 +1,1 @@
-DisplayName=Jenkins Text Finder
+TextFinderPublisher.DisplayName=Jenkins Text Finder

--- a/src/main/resources/hudson/plugins/textfinder/TextFinderPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/textfinder/TextFinderPublisher/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry field="fileSet" title="${%Files}">
     <f:textbox/>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
   This plugin is used to search for strings in workspace files. The outcome
   of this search can be used to mark the build as normal or failed.

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherAgentTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherAgentTest.java
@@ -28,7 +28,7 @@ public class TextFinderPublisherAgentTest {
             throws IOException {
         String prompt;
         if (isShell) {
-            prompt = Functions.isWindows() ? "> " : "+ ";
+            prompt = Functions.isWindows() ? ">" : "+ ";
         } else {
             prompt = "";
         }

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherAgentTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherAgentTest.java
@@ -1,0 +1,77 @@
+package hudson.plugins.textfinder;
+
+import hudson.model.Result;
+import hudson.slaves.DumbSlave;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.jenkinsci.plugins.workflow.actions.WorkspaceAction;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class TextFinderPublisherAgentTest {
+
+    private static final String UNIQUE_TEXT = "foobar";
+    private static final String ECHO_UNIQUE_TEXT = "echo " + UNIQUE_TEXT;
+    private static final String LOG_UNIQUE_TEXT = "+ " + ECHO_UNIQUE_TEXT;
+
+    @Rule public JenkinsRule rule = new JenkinsRule();
+
+    private void assertLogContainsMatch(File file, String text, WorkflowRun build)
+            throws IOException {
+        rule.assertLogContains(String.format("%s:\n%s", file, text), build);
+    }
+
+    private File getWorkspace(WorkflowRun build) {
+        FlowGraphWalker walker = new FlowGraphWalker(build.getExecution());
+        List<WorkspaceAction> actions = new ArrayList<>();
+        for (FlowNode node : walker) {
+            WorkspaceAction action = node.getAction(WorkspaceAction.class);
+            if (action != null) {
+                return new File(action.getWorkspace().getRemote());
+            }
+        }
+        throw new IllegalStateException("Failed to find workspace");
+    }
+
+    @Test
+    public void failureIfFoundInFileOnAgent() throws Exception {
+        DumbSlave agent = rule.createOnlineSlave();
+        WorkflowJob project = rule.createProject(WorkflowJob.class, "pipeline");
+        project.setDefinition(
+                new CpsFlowDefinition(
+                        String.format(
+                                "node('%s') {writeFile file: 'out.txt', text: 'foobar'}\n"
+                                        + "node('%s') {findText regexp: 'foobar', fileSet: 'out.txt'}\n",
+                                agent.getNodeName(), agent.getNodeName())));
+        WorkflowRun build = project.scheduleBuild2(0).get();
+        rule.waitForCompletion(build);
+        rule.assertLogContains("Checking foobar", build);
+        assertLogContainsMatch(new File(getWorkspace(build), "out.txt"), UNIQUE_TEXT, build);
+        rule.assertBuildStatus(Result.FAILURE, build);
+    }
+
+    @Test
+    public void failureIfFoundInConsoleOnAgent() throws Exception {
+        DumbSlave agent = rule.createOnlineSlave();
+        WorkflowJob project = rule.createProject(WorkflowJob.class, "pipeline");
+        project.setDefinition(
+                new CpsFlowDefinition(
+                        String.format(
+                                "node('%s') {isUnix() ? sh('echo foobar') : bat('echo foobar')}\n"
+                                        + "node('%s') {findText regexp: 'foobar', alsoCheckConsoleOutput: true}\n",
+                                agent.getNodeName(), agent.getNodeName())));
+        WorkflowRun build = project.scheduleBuild2(0).get();
+        rule.waitForCompletion(build);
+        rule.assertLogContains("Checking console output", build);
+        assertLogContainsMatch(build.getLogFile(), LOG_UNIQUE_TEXT, build);
+        rule.assertBuildStatus(Result.FAILURE, build);
+    }
+}

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherAgentTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherAgentTest.java
@@ -26,7 +26,8 @@ public class TextFinderPublisherAgentTest {
 
     private void assertLogContainsMatch(File file, String text, WorkflowRun build)
             throws IOException {
-        rule.assertLogContains(String.format("%s:\n%s", file, text), build);
+        rule.assertLogContains(
+                String.format("%s:%s%s", file, System.getProperty("line.separator"), text), build);
     }
 
     private File getWorkspace(WorkflowRun build) {

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
@@ -23,7 +23,8 @@ public class TextFinderPublisherFreestyleTest {
 
     private void assertLogContainsMatch(File file, String text, FreeStyleBuild build)
             throws IOException {
-        rule.assertLogContains(String.format("%s:\n%s", file, text), build);
+        rule.assertLogContains(
+                String.format("%s:%s%s", file, System.getProperty("line.separator"), text), build);
     }
 
     @Test

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
@@ -17,14 +17,21 @@ public class TextFinderPublisherFreestyleTest {
 
     private static final String UNIQUE_TEXT = "foobar";
     private static final String ECHO_UNIQUE_TEXT = "echo " + UNIQUE_TEXT;
-    private static final String LOG_UNIQUE_TEXT = "+ " + ECHO_UNIQUE_TEXT;
 
     @Rule public JenkinsRule rule = new JenkinsRule();
 
-    private void assertLogContainsMatch(File file, String text, FreeStyleBuild build)
-            throws IOException {
+    private void assertLogContainsMatch(
+            File file, String text, FreeStyleBuild build, boolean isShell) throws IOException {
+        String prompt;
+        if (isShell) {
+            prompt = Functions.isWindows() ? "> " : "+ ";
+        } else {
+            prompt = "";
+        }
         rule.assertLogContains(
-                String.format("%s:%s%s", file, System.getProperty("line.separator"), text), build);
+                String.format(
+                        "%s:%s%s%s", file, System.getProperty("line.separator"), prompt, text),
+                build);
     }
 
     @Test
@@ -32,7 +39,7 @@ public class TextFinderPublisherFreestyleTest {
         FreeStyleProject project = rule.createFreeStyleProject("freestyle");
         CommandInterpreter command =
                 Functions.isWindows()
-                        ? new BatchFile(ECHO_UNIQUE_TEXT)
+                        ? new BatchFile("prompt $G\\r\\n" + ECHO_UNIQUE_TEXT)
                         : new Shell(ECHO_UNIQUE_TEXT);
         project.getBuildersList().add(command);
         TextFinderPublisher textFinder = new TextFinderPublisher(UNIQUE_TEXT);
@@ -42,7 +49,7 @@ public class TextFinderPublisherFreestyleTest {
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains("Checking console output", build);
-        assertLogContainsMatch(build.getLogFile(), LOG_UNIQUE_TEXT, build);
+        assertLogContainsMatch(build.getLogFile(), ECHO_UNIQUE_TEXT, build, true);
         rule.assertBuildStatus(Result.SUCCESS, build);
     }
 
@@ -51,7 +58,7 @@ public class TextFinderPublisherFreestyleTest {
         FreeStyleProject project = rule.createFreeStyleProject("freestyle");
         CommandInterpreter command =
                 Functions.isWindows()
-                        ? new BatchFile(ECHO_UNIQUE_TEXT)
+                        ? new BatchFile("prompt $G\\r\\n" + ECHO_UNIQUE_TEXT)
                         : new Shell(ECHO_UNIQUE_TEXT);
         project.getBuildersList().add(command);
         TextFinderPublisher textFinder = new TextFinderPublisher(UNIQUE_TEXT);
@@ -60,7 +67,7 @@ public class TextFinderPublisherFreestyleTest {
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains("Checking console output", build);
-        assertLogContainsMatch(build.getLogFile(), LOG_UNIQUE_TEXT, build);
+        assertLogContainsMatch(build.getLogFile(), ECHO_UNIQUE_TEXT, build, true);
         rule.assertBuildStatus(Result.FAILURE, build);
     }
 
@@ -69,7 +76,7 @@ public class TextFinderPublisherFreestyleTest {
         FreeStyleProject project = rule.createFreeStyleProject("freestyle");
         CommandInterpreter command =
                 Functions.isWindows()
-                        ? new BatchFile(ECHO_UNIQUE_TEXT)
+                        ? new BatchFile("prompt $G\\r\\n" + ECHO_UNIQUE_TEXT)
                         : new Shell(ECHO_UNIQUE_TEXT);
         project.getBuildersList().add(command);
         TextFinderPublisher textFinder = new TextFinderPublisher(UNIQUE_TEXT);
@@ -79,7 +86,7 @@ public class TextFinderPublisherFreestyleTest {
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains("Checking console output", build);
-        assertLogContainsMatch(build.getLogFile(), LOG_UNIQUE_TEXT, build);
+        assertLogContainsMatch(build.getLogFile(), ECHO_UNIQUE_TEXT, build, true);
         rule.assertBuildStatus(Result.UNSTABLE, build);
     }
 

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
@@ -24,7 +24,7 @@ public class TextFinderPublisherFreestyleTest {
             File file, String text, FreeStyleBuild build, boolean isShell) throws IOException {
         String prompt;
         if (isShell) {
-            prompt = Functions.isWindows() ? "> " : "+ ";
+            prompt = Functions.isWindows() ? ">" : "+ ";
         } else {
             prompt = "";
         }

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
@@ -1,0 +1,96 @@
+package hudson.plugins.textfinder;
+
+import hudson.Functions;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.tasks.BatchFile;
+import hudson.tasks.CommandInterpreter;
+import hudson.tasks.Shell;
+import java.io.File;
+import java.io.IOException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class TextFinderPublisherFreestyleTest {
+
+    private static final String UNIQUE_TEXT = "foobar";
+    private static final String ECHO_UNIQUE_TEXT = "echo " + UNIQUE_TEXT;
+    private static final String LOG_UNIQUE_TEXT = "+ " + ECHO_UNIQUE_TEXT;
+
+    @Rule public JenkinsRule rule = new JenkinsRule();
+
+    private void assertLogContainsMatch(File file, String text, FreeStyleBuild build)
+            throws IOException {
+        rule.assertLogContains(String.format("%s:\n%s", file, text), build);
+    }
+
+    @Test
+    public void successIfFoundInConsole() throws Exception {
+        FreeStyleProject project = rule.createFreeStyleProject("freestyle");
+        CommandInterpreter command =
+                Functions.isWindows()
+                        ? new BatchFile(ECHO_UNIQUE_TEXT)
+                        : new Shell(ECHO_UNIQUE_TEXT);
+        project.getBuildersList().add(command);
+        TextFinderPublisher textFinder = new TextFinderPublisher(UNIQUE_TEXT);
+        textFinder.setSucceedIfFound(true);
+        textFinder.setAlsoCheckConsoleOutput(true);
+        project.getPublishersList().add(textFinder);
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        rule.waitForCompletion(build);
+        rule.assertLogContains("Checking console output", build);
+        assertLogContainsMatch(build.getLogFile(), LOG_UNIQUE_TEXT, build);
+        rule.assertBuildStatus(Result.SUCCESS, build);
+    }
+
+    @Test
+    public void failureIfFoundInConsole() throws Exception {
+        FreeStyleProject project = rule.createFreeStyleProject("freestyle");
+        CommandInterpreter command =
+                Functions.isWindows()
+                        ? new BatchFile(ECHO_UNIQUE_TEXT)
+                        : new Shell(ECHO_UNIQUE_TEXT);
+        project.getBuildersList().add(command);
+        TextFinderPublisher textFinder = new TextFinderPublisher(UNIQUE_TEXT);
+        textFinder.setAlsoCheckConsoleOutput(true);
+        project.getPublishersList().add(textFinder);
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        rule.waitForCompletion(build);
+        rule.assertLogContains("Checking console output", build);
+        assertLogContainsMatch(build.getLogFile(), LOG_UNIQUE_TEXT, build);
+        rule.assertBuildStatus(Result.FAILURE, build);
+    }
+
+    @Test
+    public void unstableIfFoundInConsole() throws Exception {
+        FreeStyleProject project = rule.createFreeStyleProject("freestyle");
+        CommandInterpreter command =
+                Functions.isWindows()
+                        ? new BatchFile(ECHO_UNIQUE_TEXT)
+                        : new Shell(ECHO_UNIQUE_TEXT);
+        project.getBuildersList().add(command);
+        TextFinderPublisher textFinder = new TextFinderPublisher(UNIQUE_TEXT);
+        textFinder.setUnstableIfFound(true);
+        textFinder.setAlsoCheckConsoleOutput(true);
+        project.getPublishersList().add(textFinder);
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        rule.waitForCompletion(build);
+        rule.assertLogContains("Checking console output", build);
+        assertLogContainsMatch(build.getLogFile(), LOG_UNIQUE_TEXT, build);
+        rule.assertBuildStatus(Result.UNSTABLE, build);
+    }
+
+    @Test
+    public void notFoundInConsole() throws Exception {
+        FreeStyleProject project = rule.createFreeStyleProject("freestyle");
+        TextFinderPublisher textFinder = new TextFinderPublisher(UNIQUE_TEXT);
+        textFinder.setAlsoCheckConsoleOutput(true);
+        project.getPublishersList().add(textFinder);
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        rule.waitForCompletion(build);
+        rule.assertLogContains("Checking console output", build);
+        rule.assertBuildStatus(Result.SUCCESS, build);
+    }
+}

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
@@ -39,7 +39,7 @@ public class TextFinderPublisherFreestyleTest {
         FreeStyleProject project = rule.createFreeStyleProject("freestyle");
         CommandInterpreter command =
                 Functions.isWindows()
-                        ? new BatchFile("prompt $G\\r\\n" + ECHO_UNIQUE_TEXT)
+                        ? new BatchFile("prompt $G\n" + ECHO_UNIQUE_TEXT)
                         : new Shell(ECHO_UNIQUE_TEXT);
         project.getBuildersList().add(command);
         TextFinderPublisher textFinder = new TextFinderPublisher(UNIQUE_TEXT);
@@ -58,7 +58,7 @@ public class TextFinderPublisherFreestyleTest {
         FreeStyleProject project = rule.createFreeStyleProject("freestyle");
         CommandInterpreter command =
                 Functions.isWindows()
-                        ? new BatchFile("prompt $G\\r\\n" + ECHO_UNIQUE_TEXT)
+                        ? new BatchFile("prompt $G\n" + ECHO_UNIQUE_TEXT)
                         : new Shell(ECHO_UNIQUE_TEXT);
         project.getBuildersList().add(command);
         TextFinderPublisher textFinder = new TextFinderPublisher(UNIQUE_TEXT);
@@ -76,7 +76,7 @@ public class TextFinderPublisherFreestyleTest {
         FreeStyleProject project = rule.createFreeStyleProject("freestyle");
         CommandInterpreter command =
                 Functions.isWindows()
-                        ? new BatchFile("prompt $G\\r\\n" + ECHO_UNIQUE_TEXT)
+                        ? new BatchFile("prompt $G\n" + ECHO_UNIQUE_TEXT)
                         : new Shell(ECHO_UNIQUE_TEXT);
         project.getBuildersList().add(command);
         TextFinderPublisher textFinder = new TextFinderPublisher(UNIQUE_TEXT);

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
@@ -1,0 +1,151 @@
+package hudson.plugins.textfinder;
+
+import hudson.model.Result;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.jenkinsci.plugins.workflow.actions.WorkspaceAction;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class TextFinderPublisherPipelineTest {
+
+    private static final String UNIQUE_TEXT = "foobar";
+    private static final String ECHO_UNIQUE_TEXT = "echo " + UNIQUE_TEXT;
+    private static final String LOG_UNIQUE_TEXT = "+ " + ECHO_UNIQUE_TEXT;
+
+    @Rule public JenkinsRule rule = new JenkinsRule();
+
+    private void assertLogContainsMatch(File file, String text, WorkflowRun build)
+            throws IOException {
+        rule.assertLogContains(String.format("%s:\n%s", file, text), build);
+    }
+
+    private File getWorkspace(WorkflowRun build) {
+        FlowGraphWalker walker = new FlowGraphWalker(build.getExecution());
+        List<WorkspaceAction> actions = new ArrayList<>();
+        for (FlowNode node : walker) {
+            WorkspaceAction action = node.getAction(WorkspaceAction.class);
+            if (action != null) {
+                return new File(action.getWorkspace().getRemote());
+            }
+        }
+        throw new IllegalStateException("Failed to find workspace");
+    }
+
+    @Test
+    public void successIfFoundInFile() throws Exception {
+        WorkflowJob project = rule.createProject(WorkflowJob.class, "pipeline");
+        project.setDefinition(
+                new CpsFlowDefinition(
+                        "node {writeFile file: 'out.txt', text: 'foobar'}\n"
+                                + "node {textFinder regexp: 'foobar', fileSet: 'out.txt', succeedIfFound: true}\n"));
+        WorkflowRun build = project.scheduleBuild2(0).get();
+        rule.waitForCompletion(build);
+        rule.assertLogContains("Checking foobar", build);
+        assertLogContainsMatch(new File(getWorkspace(build), "out.txt"), UNIQUE_TEXT, build);
+        rule.assertBuildStatus(Result.SUCCESS, build);
+    }
+
+    @Test
+    public void failureIfFoundInFile() throws Exception {
+        WorkflowJob project = rule.createProject(WorkflowJob.class, "pipeline");
+        project.setDefinition(
+                new CpsFlowDefinition(
+                        "node {writeFile file: 'out.txt', text: 'foobar'}\n"
+                                + "node {textFinder regexp: 'foobar', fileSet: 'out.txt'}\n"));
+        WorkflowRun build = project.scheduleBuild2(0).get();
+        rule.waitForCompletion(build);
+        rule.assertLogContains("Checking foobar", build);
+        assertLogContainsMatch(new File(getWorkspace(build), "out.txt"), UNIQUE_TEXT, build);
+        rule.assertBuildStatus(Result.FAILURE, build);
+    }
+
+    @Test
+    public void unstableIfFoundInFile() throws Exception {
+        WorkflowJob project = rule.createProject(WorkflowJob.class, "pipeline");
+        project.setDefinition(
+                new CpsFlowDefinition(
+                        "node {writeFile file: 'out.txt', text: 'foobar'}\n"
+                                + "node {textFinder regexp: 'foobar', fileSet: 'out.txt', unstableIfFound: true}\n"));
+        WorkflowRun build = project.scheduleBuild2(0).get();
+        rule.waitForCompletion(build);
+        rule.assertLogContains("Checking foobar", build);
+        assertLogContainsMatch(new File(getWorkspace(build), "out.txt"), UNIQUE_TEXT, build);
+        rule.assertBuildStatus(Result.UNSTABLE, build);
+    }
+
+    @Test
+    public void notFoundInFile() throws Exception {
+        WorkflowJob project = rule.createProject(WorkflowJob.class, "pipeline");
+        project.setDefinition(
+                new CpsFlowDefinition(
+                        "node {writeFile file: 'out.txt', text: 'foobaz'}\n"
+                                + "node {textFinder regexp: 'foobar', fileSet: 'out.txt'}\n"));
+        WorkflowRun build = project.scheduleBuild2(0).get();
+        rule.waitForCompletion(build);
+        rule.assertLogContains("Checking foobar", build);
+        rule.assertBuildStatus(Result.SUCCESS, build);
+    }
+
+    @Test
+    public void successIfFoundInConsole() throws Exception {
+        WorkflowJob project = rule.createProject(WorkflowJob.class, "pipeline");
+        project.setDefinition(
+                new CpsFlowDefinition(
+                        "node {isUnix() ? sh('echo foobar') : bat('echo foobar')}\n"
+                                + "node {textFinder regexp: 'foobar', succeedIfFound: true, alsoCheckConsoleOutput: true}\n"));
+        WorkflowRun build = project.scheduleBuild2(0).get();
+        rule.waitForCompletion(build);
+        rule.assertLogContains("Checking console output", build);
+        assertLogContainsMatch(build.getLogFile(), LOG_UNIQUE_TEXT, build);
+        rule.assertBuildStatus(Result.SUCCESS, build);
+    }
+
+    @Test
+    public void failureIfFoundInConsole() throws Exception {
+        WorkflowJob project = rule.createProject(WorkflowJob.class, "pipeline");
+        project.setDefinition(
+                new CpsFlowDefinition(
+                        "node {isUnix() ? sh('echo foobar') : bat('echo foobar')}\n"
+                                + "node {textFinder regexp: 'foobar', alsoCheckConsoleOutput: true}\n"));
+        WorkflowRun build = project.scheduleBuild2(0).get();
+        rule.waitForCompletion(build);
+        rule.assertLogContains("Checking console output", build);
+        assertLogContainsMatch(build.getLogFile(), LOG_UNIQUE_TEXT, build);
+        rule.assertBuildStatus(Result.FAILURE, build);
+    }
+
+    @Test
+    public void unstableIfFoundInConsole() throws Exception {
+        WorkflowJob project = rule.createProject(WorkflowJob.class, "pipeline");
+        project.setDefinition(
+                new CpsFlowDefinition(
+                        "node {isUnix() ? sh('echo foobar') : bat('echo foobar')}\n"
+                                + "node {textFinder regexp: 'foobar', unstableIfFound: true, alsoCheckConsoleOutput: true}\n"));
+        WorkflowRun build = project.scheduleBuild2(0).get();
+        rule.waitForCompletion(build);
+        rule.assertLogContains("Checking console output", build);
+        assertLogContainsMatch(build.getLogFile(), LOG_UNIQUE_TEXT, build);
+        rule.assertBuildStatus(Result.UNSTABLE, build);
+    }
+
+    @Test
+    public void notFoundInConsole() throws Exception {
+        WorkflowJob project = rule.createProject(WorkflowJob.class, "pipeline");
+        project.setDefinition(
+                new CpsFlowDefinition(
+                        "node {textFinder regexp: 'foobar', alsoCheckConsoleOutput: true}\n"));
+        WorkflowRun build = project.scheduleBuild2(0).get();
+        rule.waitForCompletion(build);
+        rule.assertLogContains("Checking console output", build);
+        rule.assertBuildStatus(Result.SUCCESS, build);
+    }
+}

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
@@ -27,7 +27,7 @@ public class TextFinderPublisherPipelineTest {
             throws IOException {
         String prompt;
         if (isShell) {
-            prompt = Functions.isWindows() ? "> " : "+ ";
+            prompt = Functions.isWindows() ? ">" : "+ ";
         } else {
             prompt = "";
         }

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
@@ -25,7 +25,8 @@ public class TextFinderPublisherPipelineTest {
 
     private void assertLogContainsMatch(File file, String text, WorkflowRun build)
             throws IOException {
-        rule.assertLogContains(String.format("%s:\n%s", file, text), build);
+        rule.assertLogContains(
+                String.format("%s:%s%s", file, System.getProperty("line.separator"), text), build);
     }
 
     private File getWorkspace(WorkflowRun build) {

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
@@ -46,7 +46,7 @@ public class TextFinderPublisherPipelineTest {
         project.setDefinition(
                 new CpsFlowDefinition(
                         "node {writeFile file: 'out.txt', text: 'foobar'}\n"
-                                + "node {textFinder regexp: 'foobar', fileSet: 'out.txt', succeedIfFound: true}\n"));
+                                + "node {findText regexp: 'foobar', fileSet: 'out.txt', succeedIfFound: true}\n"));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains("Checking foobar", build);
@@ -60,7 +60,7 @@ public class TextFinderPublisherPipelineTest {
         project.setDefinition(
                 new CpsFlowDefinition(
                         "node {writeFile file: 'out.txt', text: 'foobar'}\n"
-                                + "node {textFinder regexp: 'foobar', fileSet: 'out.txt'}\n"));
+                                + "node {findText regexp: 'foobar', fileSet: 'out.txt'}\n"));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains("Checking foobar", build);
@@ -74,7 +74,7 @@ public class TextFinderPublisherPipelineTest {
         project.setDefinition(
                 new CpsFlowDefinition(
                         "node {writeFile file: 'out.txt', text: 'foobar'}\n"
-                                + "node {textFinder regexp: 'foobar', fileSet: 'out.txt', unstableIfFound: true}\n"));
+                                + "node {findText regexp: 'foobar', fileSet: 'out.txt', unstableIfFound: true}\n"));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains("Checking foobar", build);
@@ -88,7 +88,7 @@ public class TextFinderPublisherPipelineTest {
         project.setDefinition(
                 new CpsFlowDefinition(
                         "node {writeFile file: 'out.txt', text: 'foobaz'}\n"
-                                + "node {textFinder regexp: 'foobar', fileSet: 'out.txt'}\n"));
+                                + "node {findText regexp: 'foobar', fileSet: 'out.txt'}\n"));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains("Checking foobar", build);
@@ -101,7 +101,7 @@ public class TextFinderPublisherPipelineTest {
         project.setDefinition(
                 new CpsFlowDefinition(
                         "node {isUnix() ? sh('echo foobar') : bat('echo foobar')}\n"
-                                + "node {textFinder regexp: 'foobar', succeedIfFound: true, alsoCheckConsoleOutput: true}\n"));
+                                + "node {findText regexp: 'foobar', succeedIfFound: true, alsoCheckConsoleOutput: true}\n"));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains("Checking console output", build);
@@ -115,7 +115,7 @@ public class TextFinderPublisherPipelineTest {
         project.setDefinition(
                 new CpsFlowDefinition(
                         "node {isUnix() ? sh('echo foobar') : bat('echo foobar')}\n"
-                                + "node {textFinder regexp: 'foobar', alsoCheckConsoleOutput: true}\n"));
+                                + "node {findText regexp: 'foobar', alsoCheckConsoleOutput: true}\n"));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains("Checking console output", build);
@@ -129,7 +129,7 @@ public class TextFinderPublisherPipelineTest {
         project.setDefinition(
                 new CpsFlowDefinition(
                         "node {isUnix() ? sh('echo foobar') : bat('echo foobar')}\n"
-                                + "node {textFinder regexp: 'foobar', unstableIfFound: true, alsoCheckConsoleOutput: true}\n"));
+                                + "node {findText regexp: 'foobar', unstableIfFound: true, alsoCheckConsoleOutput: true}\n"));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains("Checking console output", build);
@@ -142,7 +142,7 @@ public class TextFinderPublisherPipelineTest {
         WorkflowJob project = rule.createProject(WorkflowJob.class, "pipeline");
         project.setDefinition(
                 new CpsFlowDefinition(
-                        "node {textFinder regexp: 'foobar', alsoCheckConsoleOutput: true}\n"));
+                        "node {findText regexp: 'foobar', alsoCheckConsoleOutput: true}\n"));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains("Checking console output", build);


### PR DESCRIPTION
### Problem

The Text Finder plugin doesn't support Pipeline. It also has an old parent POM.

### Solution

Add Pipeline support and update the parent POM to the latest version.

### Implementation

I started by updating the parent POM to the latest version and specifying a minimum Jenkins version that had decent Pipeline support. I also added `structs` to the dependency list (for using `@Symbol`) and added the Pipeline plugin dependencies required for testing. Updating to the latest parent POM necessitated adding `<?jelly escape-by-default='true'?>` to the `.jelly` files.

To add Pipeline support to the plugin, I made it implement `SimpleBuildStep` [as recommended in the documentation](https://jenkins.io/doc/developer/plugin-development/pipeline-integration/). As suggested in the "Constructor vs. setters" section of the documentation, I replaced the lengthy existing `@DataBoundConstructor` with a short one taking just truly mandatory parameters. For all optional parameters, I created a public setter marked with `@DataBoundSetter` (with any non-null default value set in the constructor or field initializer). This allows most parameters to be left at their default values in a Pipeline script, not to mention simplifying ongoing code maintenance because it is much easier to introduce new options this way. For Java-level compatibility, I left the previous constructor in place, but marked it `@Deprecated`. I also removed `@DataBoundConstructor` from it (there can be only one). Finally, I added a `textFinder` symbol (with `@Symbol`) to make use of this plugin from Pipeline more elegant.

Bumping the minimum Jenkins version resulted in a compilation error in `FileCallable`, so I replaced this with a call to the newer `MasterToSlaveFileCallable` class. I also extracted this callable into a static class to prevent [warnings about Remoting serialization of anonymous inner classes](https://issues.jenkins-ci.org/browse/JENKINS-49994). This necessitated marking a few methods called by the `Callable` as static methods.

### Testing

This plugin had no tests, so I wrote some tests for both Freestyle and Pipeline jobs. The tests get about 60% coverage of the plugin. I got coverage of all the positive code paths and some (but not all) of the error conditions.