### PR TITLE
Fix Japanese translation

### DIFF
--- a/src/main/resources/hudson/plugins/textfinder/Messages_ja.properties
+++ b/src/main/resources/hudson/plugins/textfinder/Messages_ja.properties
@@ -1,1 +1,1 @@
-DisplayName=Jenkins\u6587\u5b57\u5217\u691c\u7d22
+TextFinderPublisher.DisplayName=Jenkins\u6587\u5b57\u5217\u691c\u7d22


### PR DESCRIPTION
In #12, I fixed a FindBugs warning by updating a message string. However, I neglected to make the corresponding change to the Japanese translation. Here I correct this oversight.