### PR TITLE
Format repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,37 +1,62 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.jenkins-ci.plugins</groupId>
-    <artifactId>plugin</artifactId>
-    <version>3.15</version>
-    <relativePath />
-  </parent>
-  
-  <artifactId>text-finder</artifactId>
-  <packaging>hpi</packaging>
-  <version>1.11-SNAPSHOT</version>
-  <name>Jenkins TextFinder plugin</name>
-  <url>http://wiki.jenkins-ci.org/display/JENKINS/Text-finder+Plugin</url>
-  <properties>
-    <jenkins.version>1.651</jenkins.version>
-    <java.level>7</java.level>
-  </properties>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>3.15</version>
+        <relativePath />
+    </parent>
 
-  <developers>
-    <developer>
-      <id>kohsuke</id>
-      <name>Kohsuke Kawaguchi</name>
-    </developer>
-    <developer>
-      <name>Santiago Pericas-Geertsen</name>
-    </developer>
-  </developers>
+    <artifactId>text-finder</artifactId>
+    <packaging>hpi</packaging>
+    <version>1.11-SNAPSHOT</version>
+    <name>Jenkins TextFinder plugin</name>
+    <url>http://wiki.jenkins-ci.org/display/JENKINS/Text-finder+Plugin</url>
+    <properties>
+        <jenkins.version>1.651</jenkins.version>
+        <java.level>7</java.level>
+    </properties>
+
+    <developers>
+        <developer>
+            <id>kohsuke</id>
+            <name>Kohsuke Kawaguchi</name>
+        </developer>
+        <developer>
+            <name>Santiago Pericas-Geertsen</name>
+        </developer>
+        <developer>
+            <id>basil</id>
+            <name>Basil Crow</name>
+        </developer>
+    </developers>
+
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     </scm>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.coveo</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>2.5.0</version>
+                <configuration>
+                    <style>aosp</style>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <dependency>
@@ -78,6 +103,4 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-</project>  
-  
-
+</project>

--- a/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
@@ -176,7 +176,7 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
                 }
             }
         } catch (IOException e) {
-            logger.println("Jenkins Text Finder: Error reading" + " file '" + f + "' -- ignoring");
+            logger.println("Jenkins Text Finder: Error reading file '" + f + "' -- ignoring");
         } finally {
             IOUtils.closeQuietly(reader);
         }


### PR DESCRIPTION
### Problem

While working on this plugin this past week, I found it frustrating that the formatting was inconsistent. This made it difficult to create new changes that weren't polluted by formatting noise.

### Solution

I formatted the existing code with [google-java-format](https://github.com/google/google-java-format). Then I added [fmt-maven-plugin](https://github.com/coveo/fmt-maven-plugin) to the Maven configuration to enforce that the repository stays formatted as new changes are added.

### Bonus

- Formatted `pom.xml` manually by making the indentation consistent.
- Fixed some Javadoc warnings.
- Added my name to the developers list.