### PR TITLE
Multiple finders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,14 +41,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>com.coveo</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
                 <version>2.5.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,14 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.coveo</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
                 <version>2.5.0</version>

--- a/src/main/java/hudson/plugins/textfinder/TextFinderModel.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderModel.java
@@ -7,7 +7,6 @@ import hudson.model.Descriptor;
 import java.io.Serializable;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
-import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public final class TextFinderModel extends AbstractDescribableImpl<TextFinderModel>
@@ -69,7 +68,6 @@ public final class TextFinderModel extends AbstractDescribableImpl<TextFinderMod
         return alsoCheckConsoleOutput;
     }
 
-    @Symbol("finder")
     @Extension
     public static class DescriptorImpl extends Descriptor<TextFinderModel> {
         @Override

--- a/src/main/java/hudson/plugins/textfinder/TextFinderModel.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderModel.java
@@ -72,7 +72,7 @@ public final class TextFinderModel extends AbstractDescribableImpl<TextFinderMod
     public static class DescriptorImpl extends Descriptor<TextFinderModel> {
         @Override
         public String getDisplayName() {
-            return "Text finder";
+            return "Text Finder";
         }
     }
 }

--- a/src/main/java/hudson/plugins/textfinder/TextFinderModel.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderModel.java
@@ -13,13 +13,13 @@ public final class TextFinderModel extends AbstractDescribableImpl<TextFinderMod
         implements Serializable {
     private static final long serialVersionUID = 7645849785536280615L;
 
-    public final String fileSet;
-    public final String regexp;
-    public final boolean succeedIfFound;
-    public final boolean unstableIfFound;
-    public final boolean notBuiltIfFound;
+    private final String fileSet;
+    private final String regexp;
+    private final boolean succeedIfFound;
+    private final boolean unstableIfFound;
+    private final boolean notBuiltIfFound;
     /** True to also scan the whole console output */
-    public final boolean alsoCheckConsoleOutput;
+    private final boolean alsoCheckConsoleOutput;
 
     @DataBoundConstructor
     public TextFinderModel(

--- a/src/main/java/hudson/plugins/textfinder/TextFinderModel.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderModel.java
@@ -7,6 +7,7 @@ import hudson.model.Descriptor;
 import java.io.Serializable;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public final class TextFinderModel extends AbstractDescribableImpl<TextFinderModel>
@@ -68,6 +69,7 @@ public final class TextFinderModel extends AbstractDescribableImpl<TextFinderMod
         return alsoCheckConsoleOutput;
     }
 
+    @Symbol("finder")
     @Extension
     public static class DescriptorImpl extends Descriptor<TextFinderModel> {
         @Override

--- a/src/main/java/hudson/plugins/textfinder/TextFinderModel.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderModel.java
@@ -11,7 +11,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 public final class TextFinderModel extends AbstractDescribableImpl<TextFinderModel>
         implements Serializable {
-    private static final long serialVersionUID = 7645849785536280615L;
+    private static final long serialVersionUID = 1L;
 
     private final String fileSet;
     private final String regexp;

--- a/src/main/java/hudson/plugins/textfinder/TextFinderModel.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderModel.java
@@ -4,13 +4,13 @@ import hudson.Extension;
 import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
-import org.kohsuke.stapler.DataBoundConstructor;
-
 import java.io.Serializable;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import org.kohsuke.stapler.DataBoundConstructor;
 
-public final class TextFinderModel extends AbstractDescribableImpl<TextFinderModel> implements Serializable {
+public final class TextFinderModel extends AbstractDescribableImpl<TextFinderModel>
+        implements Serializable {
     private static final long serialVersionUID = 7645849785536280615L;
 
     public final String fileSet;
@@ -18,13 +18,17 @@ public final class TextFinderModel extends AbstractDescribableImpl<TextFinderMod
     public final boolean succeedIfFound;
     public final boolean unstableIfFound;
     public final boolean notBuiltIfFound;
-    /**
-     * True to also scan the whole console output
-     */
+    /** True to also scan the whole console output */
     public final boolean alsoCheckConsoleOutput;
 
     @DataBoundConstructor
-    public TextFinderModel(String fileSet, String regexp, boolean succeedIfFound, boolean unstableIfFound, boolean alsoCheckConsoleOutput, boolean notBuiltIfFound) {
+    public TextFinderModel(
+            String fileSet,
+            String regexp,
+            boolean succeedIfFound,
+            boolean unstableIfFound,
+            boolean alsoCheckConsoleOutput,
+            boolean notBuiltIfFound) {
         this.fileSet = fileSet != null ? Util.fixEmpty(fileSet.trim()) : null;
         this.regexp = regexp;
         this.succeedIfFound = succeedIfFound;

--- a/src/main/java/hudson/plugins/textfinder/TextFinderModel.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderModel.java
@@ -1,0 +1,74 @@
+package hudson.plugins.textfinder;
+
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.Serializable;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+public final class TextFinderModel extends AbstractDescribableImpl<TextFinderModel> implements Serializable {
+    private static final long serialVersionUID = 7645849785536280615L;
+
+    public final String fileSet;
+    public final String regexp;
+    public final boolean succeedIfFound;
+    public final boolean unstableIfFound;
+    public final boolean notBuiltIfFound;
+    /**
+     * True to also scan the whole console output
+     */
+    public final boolean alsoCheckConsoleOutput;
+
+    @DataBoundConstructor
+    public TextFinderModel(String fileSet, String regexp, boolean succeedIfFound, boolean unstableIfFound, boolean alsoCheckConsoleOutput, boolean notBuiltIfFound) {
+        this.fileSet = fileSet != null ? Util.fixEmpty(fileSet.trim()) : null;
+        this.regexp = regexp;
+        this.succeedIfFound = succeedIfFound;
+        this.unstableIfFound = unstableIfFound;
+        this.alsoCheckConsoleOutput = alsoCheckConsoleOutput;
+        this.notBuiltIfFound = notBuiltIfFound;
+
+        // Attempt to compile regular expression
+        try {
+            Pattern.compile(regexp);
+        } catch (PatternSyntaxException e) {
+            // falls through
+        }
+    }
+
+    public String getFileSet() {
+        return fileSet;
+    }
+
+    public String getRegexp() {
+        return regexp;
+    }
+
+    public boolean isSucceedIfFound() {
+        return succeedIfFound;
+    }
+
+    public boolean isUnstableIfFound() {
+        return unstableIfFound;
+    }
+
+    public boolean isNotBuiltIfFound() {
+        return notBuiltIfFound;
+    }
+
+    public boolean isAlsoCheckConsoleOutput() {
+        return alsoCheckConsoleOutput;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<TextFinderModel> {
+        @Override
+        public String getDisplayName() {
+            return "Text finder";
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
@@ -274,7 +274,12 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
         }
 
         public List<TextFinderModel.DescriptorImpl> getItemDescriptors() {
-            return Jenkins.getInstance().getDescriptorList(TextFinderModel.class);
+            Jenkins jenkins = Jenkins.getInstance();
+            if (jenkins != null) {
+                return jenkins.getDescriptorList(TextFinderModel.class);
+            } else {
+                throw new NullPointerException("not able to get Jenkins instance");
+            }
         }
 
         /**

--- a/src/main/resources/hudson/plugins/textfinder/TextFinderModel/config.jelly
+++ b/src/main/resources/hudson/plugins/textfinder/TextFinderModel/config.jelly
@@ -19,12 +19,4 @@
   <f:entry field="notBuiltIfFound" title="${%Not Built if found}">
     <f:checkbox/>
   </f:entry>
-  <f:entry field="textFinders">
-    <f:hetero-list name="textFinders"
-                   hasHeader="true"
-                   descriptors="${descriptor.itemDescriptors}"
-                   items="${instance.textFinders}"
-                   addCaption="Add Text finder"
-                   deleteCaption="Delete Text finder"/>
-  </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/textfinder/TextFinderPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/textfinder/TextFinderPublisher/config.jelly
@@ -24,7 +24,7 @@
                    hasHeader="true"
                    descriptors="${descriptor.itemDescriptors}"
                    items="${instance.textFinders}"
-                   addCaption="Add Text finder"
-                   deleteCaption="Delete Text finder"/>
+                   addCaption="Add Text Finder"
+                   deleteCaption="Delete Text Finder"/>
   </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/textfinder/TextFinderPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/textfinder/TextFinderPublisher/config.jelly
@@ -19,12 +19,12 @@
   <f:entry field="notBuiltIfFound" title="${%Not Built if found}">
     <f:checkbox/>
   </f:entry>
-  <f:entry field="textFinders">
-    <f:hetero-list name="textFinders"
+  <f:entry field="additionalTextFinders">
+    <f:hetero-list name="additionalTextFinders"
                    hasHeader="true"
                    descriptors="${descriptor.itemDescriptors}"
-                   items="${instance.textFinders}"
-                   addCaption="Add Text Finder"
-                   deleteCaption="Delete Text Finder"/>
+                   items="${instance.additionalTextFinders}"
+                   addCaption="Add additional Text Finder"
+                   deleteCaption="Delete additional Text Finder"/>
   </f:entry>
 </j:jelly>

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherAgentTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherAgentTest.java
@@ -92,11 +92,11 @@ public class TextFinderPublisherAgentTest {
                 new CpsFlowDefinition(
                         String.format(
                                 "node('%s') {isUnix() ? sh('echo foobar') : bat(\"prompt \\$G\\r\\necho foobar\")}\n"
-                                        + "node('%s') {findText regexp: 'foobar', alsoCheckConsoleOutput: true, "
-                                        + "textFinders: ["
-                                        + "finder(regexp: 'foobar', unstableIfFound: true, alsoCheckConsoleOutput: true),"
-                                        + "finder(regexp: 'foobar', notBuiltIfFound: true, alsoCheckConsoleOutput: true)"
-                                        + "]}",
+                                        + "node('%s') {"
+                                        + "findText regexp: 'foobar', alsoCheckConsoleOutput: true\n"
+                                        + "findText regexp: 'foobar', unstableIfFound: true, alsoCheckConsoleOutput: true\n"
+                                        + "findText regexp: 'foobar', notBuiltIfFound: true, alsoCheckConsoleOutput: true\n"
+                                        + "}",
                                 agent.getNodeName(), agent.getNodeName())));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherAgentTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherAgentTest.java
@@ -107,7 +107,12 @@ public class TextFinderPublisherAgentTest {
                                 agent.getNodeName(), agent.getNodeName())));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
-        rule.assertLogContains("Checking console output", build);
+        rule.assertLogContains("[Text Finder] Scanning console output...", build);
+        rule.assertLogContains(
+                "[Text Finder] Finished looking for pattern '"
+                        + UNIQUE_TEXT
+                        + "' in the console output",
+                build);
         assertLogContainsMatch(build.getLogFile(), ECHO_UNIQUE_TEXT, build, true);
         rule.assertBuildStatus(Result.NOT_BUILT, build);
     }

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
@@ -9,6 +9,8 @@ import hudson.tasks.CommandInterpreter;
 import hudson.tasks.Shell;
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -42,9 +44,8 @@ public class TextFinderPublisherFreestyleTest {
                         ? new BatchFile("prompt $G\n" + ECHO_UNIQUE_TEXT)
                         : new Shell(ECHO_UNIQUE_TEXT);
         project.getBuildersList().add(command);
-        TextFinderPublisher textFinder = new TextFinderPublisher(UNIQUE_TEXT);
-        textFinder.setSucceedIfFound(true);
-        textFinder.setAlsoCheckConsoleOutput(true);
+        TextFinderPublisher textFinder = new TextFinderPublisher("", UNIQUE_TEXT, true, false, false, true,
+                Collections.<TextFinderModel>emptyList());
         project.getPublishersList().add(textFinder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
@@ -61,8 +62,8 @@ public class TextFinderPublisherFreestyleTest {
                         ? new BatchFile("prompt $G\n" + ECHO_UNIQUE_TEXT)
                         : new Shell(ECHO_UNIQUE_TEXT);
         project.getBuildersList().add(command);
-        TextFinderPublisher textFinder = new TextFinderPublisher(UNIQUE_TEXT);
-        textFinder.setAlsoCheckConsoleOutput(true);
+        TextFinderPublisher textFinder = new TextFinderPublisher("", UNIQUE_TEXT, false, false, false, true,
+                Collections.<TextFinderModel>emptyList());
         project.getPublishersList().add(textFinder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
@@ -79,9 +80,8 @@ public class TextFinderPublisherFreestyleTest {
                         ? new BatchFile("prompt $G\n" + ECHO_UNIQUE_TEXT)
                         : new Shell(ECHO_UNIQUE_TEXT);
         project.getBuildersList().add(command);
-        TextFinderPublisher textFinder = new TextFinderPublisher(UNIQUE_TEXT);
-        textFinder.setUnstableIfFound(true);
-        textFinder.setAlsoCheckConsoleOutput(true);
+        TextFinderPublisher textFinder = new TextFinderPublisher("", UNIQUE_TEXT, false, true, false, true,
+                Collections.<TextFinderModel>emptyList());
         project.getPublishersList().add(textFinder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
@@ -93,8 +93,8 @@ public class TextFinderPublisherFreestyleTest {
     @Test
     public void notFoundInConsole() throws Exception {
         FreeStyleProject project = rule.createFreeStyleProject("freestyle");
-        TextFinderPublisher textFinder = new TextFinderPublisher(UNIQUE_TEXT);
-        textFinder.setAlsoCheckConsoleOutput(true);
+        TextFinderPublisher textFinder = new TextFinderPublisher("", UNIQUE_TEXT, false, false, false, true,
+                Collections.<TextFinderModel>emptyList());
         project.getPublishersList().add(textFinder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -46,8 +45,15 @@ public class TextFinderPublisherFreestyleTest {
                         ? new BatchFile("prompt $G\n" + ECHO_UNIQUE_TEXT)
                         : new Shell(ECHO_UNIQUE_TEXT);
         project.getBuildersList().add(command);
-        TextFinderPublisher textFinder = new TextFinderPublisher("", UNIQUE_TEXT, true, false, false, true,
-                Collections.<TextFinderModel>emptyList());
+        TextFinderPublisher textFinder =
+                new TextFinderPublisher(
+                        "",
+                        UNIQUE_TEXT,
+                        true,
+                        false,
+                        false,
+                        true,
+                        Collections.<TextFinderModel>emptyList());
         project.getPublishersList().add(textFinder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
@@ -64,8 +70,15 @@ public class TextFinderPublisherFreestyleTest {
                         ? new BatchFile("prompt $G\n" + ECHO_UNIQUE_TEXT)
                         : new Shell(ECHO_UNIQUE_TEXT);
         project.getBuildersList().add(command);
-        TextFinderPublisher textFinder = new TextFinderPublisher("", UNIQUE_TEXT, false, false, false, true,
-                Collections.<TextFinderModel>emptyList());
+        TextFinderPublisher textFinder =
+                new TextFinderPublisher(
+                        "",
+                        UNIQUE_TEXT,
+                        false,
+                        false,
+                        false,
+                        true,
+                        Collections.<TextFinderModel>emptyList());
         project.getPublishersList().add(textFinder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
@@ -82,8 +95,15 @@ public class TextFinderPublisherFreestyleTest {
                         ? new BatchFile("prompt $G\n" + ECHO_UNIQUE_TEXT)
                         : new Shell(ECHO_UNIQUE_TEXT);
         project.getBuildersList().add(command);
-        TextFinderPublisher textFinder = new TextFinderPublisher("", UNIQUE_TEXT, false, true, false, true,
-                Collections.<TextFinderModel>emptyList());
+        TextFinderPublisher textFinder =
+                new TextFinderPublisher(
+                        "",
+                        UNIQUE_TEXT,
+                        false,
+                        true,
+                        false,
+                        true,
+                        Collections.<TextFinderModel>emptyList());
         project.getPublishersList().add(textFinder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
@@ -95,8 +115,15 @@ public class TextFinderPublisherFreestyleTest {
     @Test
     public void notFoundInConsole() throws Exception {
         FreeStyleProject project = rule.createFreeStyleProject("freestyle");
-        TextFinderPublisher textFinder = new TextFinderPublisher("", UNIQUE_TEXT, false, false, false, true,
-                Collections.<TextFinderModel>emptyList());
+        TextFinderPublisher textFinder =
+                new TextFinderPublisher(
+                        "",
+                        UNIQUE_TEXT,
+                        false,
+                        false,
+                        false,
+                        true,
+                        Collections.<TextFinderModel>emptyList());
         project.getPublishersList().add(textFinder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
@@ -114,10 +141,19 @@ public class TextFinderPublisherFreestyleTest {
         project.getBuildersList().add(command);
 
         List<TextFinderModel> finders = new ArrayList<>();
-        finders.add(new TextFinderModel("", UNIQUE_TEXT, false, true, false, true));    // 2nd
-        finders.add(new TextFinderModel("", UNIQUE_TEXT, false, false, false, true));   // 3rd, this one must win
-        TextFinderPublisher textFinder = new TextFinderPublisher("", UNIQUE_TEXT, false, true, false, true,
-                finders);   // 1st will be finder with args from constructor
+        finders.add(new TextFinderModel("", UNIQUE_TEXT, false, true, false, true)); // 2nd
+        finders.add(
+                new TextFinderModel(
+                        "", UNIQUE_TEXT, false, false, false, true)); // 3rd, this one must win
+        TextFinderPublisher textFinder =
+                new TextFinderPublisher(
+                        "",
+                        UNIQUE_TEXT,
+                        false,
+                        true,
+                        false,
+                        true,
+                        finders); // 1st will be finder with args from constructor
         project.getPublishersList().add(textFinder);
 
         FreeStyleBuild build = project.scheduleBuild2(0).get();

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
@@ -178,7 +178,12 @@ public class TextFinderPublisherFreestyleTest {
 
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
-        rule.assertLogContains("Checking console output", build);
+        rule.assertLogContains("[Text Finder] Scanning console output...", build);
+        rule.assertLogContains(
+                "[Text Finder] Finished looking for pattern '"
+                        + UNIQUE_TEXT
+                        + "' in the console output",
+                build);
         assertLogContainsMatch(build.getLogFile(), ECHO_UNIQUE_TEXT, build, true);
         rule.assertBuildStatus(Result.UNSTABLE, build);
     }

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
@@ -324,7 +324,12 @@ public class TextFinderPublisherPipelineTest {
                                 + "}"));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
-        rule.assertLogContains("Checking console output", build);
+        rule.assertLogContains("[Text Finder] Scanning console output...", build);
+        rule.assertLogContains(
+                "[Text Finder] Finished looking for pattern '"
+                        + UNIQUE_TEXT
+                        + "' in the console output",
+                build);
         assertLogContainsMatch(build.getLogFile(), ECHO_UNIQUE_TEXT, build, true);
         rule.assertBuildStatus(Result.NOT_BUILT, build);
     }

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
@@ -192,11 +192,11 @@ public class TextFinderPublisherPipelineTest {
         project.setDefinition(
                 new CpsFlowDefinition(
                         "node {isUnix() ? sh('echo foobar') : bat(\"prompt \\$G\\r\\necho foobar\")}\n"
-                                + "node {findText regexp: 'foobar', alsoCheckConsoleOutput: true, "
-                                + "textFinders: ["
-                                + "finder(regexp: 'foobar', unstableIfFound: true, alsoCheckConsoleOutput: true),"
-                                + "finder(regexp: 'foobar', notBuiltIfFound: true, alsoCheckConsoleOutput: true)"
-                                + "]}"));
+                                + "node {"
+                                + "findText regexp: 'foobar', alsoCheckConsoleOutput: true\n"
+                                + "findText regexp: 'foobar', unstableIfFound: true, alsoCheckConsoleOutput: true\n"
+                                + "findText regexp: 'foobar', notBuiltIfFound: true, alsoCheckConsoleOutput: true\n"
+                                + "}"));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains("Checking console output", build);


### PR DESCRIPTION
This adds possibility to set multiple text finders to one build. Last one wins.
It's done in backward compatible way so no current configuration will be affected. I've kept support for pipelines. This patch replaces PR #9.

some implementation details:
- I've replaced setters and set all fields final to keep it safer
- Instead of fields in `TextFinderPublisher` there is new `TextFinderModel` which is simple data object with all fields.
- `TextFinderPublisher` have one `TextFinderModel` for base configuration and is providing it's values via "fake" getters. Other text finders are stored in list.
- first base text finder is executed, then it loops through list of other finders

pipelines config looks like this:
```
node {
    echo 'foobar'
}

node {
    findText regexp: 'foobar', alsoCheckConsoleOutput: true, textFinders: [
        finder(regexp: 'foobar', unstableIfFound: true, alsoCheckConsoleOutput: true),
        finder(regexp: 'foobar', notBuiltIfFound: true, alsoCheckConsoleOutput: true)]
}
```