### PR TITLE
Make naming consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Text Finder Plugin
+# Text Finder
 
 [![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/text-finder-plugin/master)](https://ci.jenkins.io/job/Plugins/job/text-finder-plugin/job/master/)
 [![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/text-finder.svg)](https://plugins.jenkins.io/text-finder)

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>text-finder</artifactId>
     <packaging>hpi</packaging>
     <version>${revision}${changelist}</version>
-    <name>Jenkins TextFinder plugin</name>
+    <name>Text Finder</name>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Text-finder+Plugin</url>
     <properties>
         <revision>1.12</revision>

--- a/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
@@ -129,7 +129,7 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
 
             if (alsoCheckConsoleOutput) {
                 // Do not mention the pattern we are looking for to avoid false positives
-                logger.println("[TextFinder plugin] Scanning console output...");
+                logger.println("[Text Finder] Scanning console output...");
                 foundText |=
                         checkFile(
                                 run.getLogFile(),
@@ -138,7 +138,7 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
                                 run.getCharset(),
                                 true);
                 logger.println(
-                        "[TextFinder plugin] Finished looking for pattern "
+                        "[Text Finder] Finished looking for pattern "
                                 + "'"
                                 + regexp
                                 + "'"
@@ -149,7 +149,7 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
 
             if (fileSet != null) {
                 logger.println(
-                        "[TextFinder plugin] Looking for pattern "
+                        "[Text Finder] Looking for pattern "
                                 + "'"
                                 + regexp
                                 + "'"
@@ -210,7 +210,7 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
                 }
             }
         } catch (IOException e) {
-            logger.println("Jenkins Text Finder: Error reading file '" + f + "' -- ignoring");
+            logger.println("[Text Finder] Error reading file '" + f + "' -- ignoring");
         } finally {
             IOUtils.closeQuietly(reader);
         }
@@ -222,8 +222,7 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
         try {
             pattern = Pattern.compile(regexp);
         } catch (PatternSyntaxException e) {
-            logger.println(
-                    "Jenkins Text Finder: Unable to compile regular expression '" + regexp + "'");
+            logger.println("[Text Finder] Unable to compile regular expression '" + regexp + "'");
             throw new AbortException();
         }
         return pattern;
@@ -298,7 +297,7 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
             // Any files in the final set?
             String[] files = ds.getIncludedFiles();
             if (files.length == 0) {
-                logger.println("Jenkins Text Finder: File set '" + fileSet + "' is empty");
+                logger.println("[Text Finder] File set '" + fileSet + "' is empty");
                 throw new AbortException();
             }
 
@@ -310,12 +309,12 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
                 File f = new File(ws, file);
 
                 if (!f.exists()) {
-                    logger.println("Jenkins Text Finder: Unable to find file '" + f + "'");
+                    logger.println("[Text Finder] Unable to find file '" + f + "'");
                     continue;
                 }
 
                 if (!f.canRead()) {
-                    logger.println("Jenkins Text Finder: Unable to read from file '" + f + "'");
+                    logger.println("[Text Finder] Unable to read from file '" + f + "'");
                     continue;
                 }
 

--- a/src/main/resources/hudson/plugins/textfinder/Messages.properties
+++ b/src/main/resources/hudson/plugins/textfinder/Messages.properties
@@ -1,1 +1,1 @@
-TextFinderPublisher.DisplayName=Jenkins Text Finder
+TextFinderPublisher.DisplayName=Text Finder

--- a/src/main/resources/hudson/plugins/textfinder/Messages_ja.properties
+++ b/src/main/resources/hudson/plugins/textfinder/Messages_ja.properties
@@ -1,1 +1,1 @@
-TextFinderPublisher.DisplayName=Jenkins\u6587\u5b57\u5217\u691c\u7d22
+TextFinderPublisher.DisplayName=\u6587\u5b57\u5217\u691c\u7d22

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherAgentTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherAgentTest.java
@@ -63,11 +63,7 @@ public class TextFinderPublisherAgentTest {
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains(
-                "[TextFinder plugin] Looking for pattern "
-                        + "'"
-                        + UNIQUE_TEXT
-                        + "'"
-                        + " in the files at",
+                "[Text Finder] Looking for pattern " + "'" + UNIQUE_TEXT + "'" + " in the files at",
                 build);
         assertLogContainsMatch(new File(getWorkspace(build), "out.txt"), UNIQUE_TEXT, build, false);
         rule.assertBuildStatus(Result.FAILURE, build);
@@ -85,9 +81,9 @@ public class TextFinderPublisherAgentTest {
                                 agent.getNodeName(), agent.getNodeName())));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
-        rule.assertLogContains("[TextFinder plugin] Scanning console output...", build);
+        rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
-                "[TextFinder plugin] Finished looking for pattern '"
+                "[Text Finder] Finished looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
@@ -48,9 +48,9 @@ public class TextFinderPublisherFreestyleTest {
         project.getPublishersList().add(textFinder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
-        rule.assertLogContains("[TextFinder plugin] Scanning console output...", build);
+        rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
-                "[TextFinder plugin] Finished looking for pattern '"
+                "[Text Finder] Finished looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);
@@ -71,9 +71,9 @@ public class TextFinderPublisherFreestyleTest {
         project.getPublishersList().add(textFinder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
-        rule.assertLogContains("[TextFinder plugin] Scanning console output...", build);
+        rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
-                "[TextFinder plugin] Finished looking for pattern '"
+                "[Text Finder] Finished looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);
@@ -95,9 +95,9 @@ public class TextFinderPublisherFreestyleTest {
         project.getPublishersList().add(textFinder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
-        rule.assertLogContains("[TextFinder plugin] Scanning console output...", build);
+        rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
-                "[TextFinder plugin] Finished looking for pattern '"
+                "[Text Finder] Finished looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);
@@ -113,9 +113,9 @@ public class TextFinderPublisherFreestyleTest {
         project.getPublishersList().add(textFinder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
-        rule.assertLogContains("[TextFinder plugin] Scanning console output...", build);
+        rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
-                "[TextFinder plugin] Finished looking for pattern '"
+                "[Text Finder] Finished looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
@@ -68,7 +68,7 @@ public class TextFinderPublisherPipelineTest {
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains(
-                "[TextFinder plugin] Looking for pattern '"
+                "[Text Finder] Looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the files at "
                         + "'"
@@ -97,7 +97,7 @@ public class TextFinderPublisherPipelineTest {
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains(
-                "[TextFinder plugin] Looking for pattern '"
+                "[Text Finder] Looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the files at "
                         + "'"
@@ -126,7 +126,7 @@ public class TextFinderPublisherPipelineTest {
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains(
-                "[TextFinder plugin] Looking for pattern '"
+                "[Text Finder] Looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the files at "
                         + "'"
@@ -155,7 +155,7 @@ public class TextFinderPublisherPipelineTest {
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains(
-                "[TextFinder plugin] Looking for pattern '"
+                "[Text Finder] Looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the files at "
                         + "'"
@@ -182,7 +182,7 @@ public class TextFinderPublisherPipelineTest {
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains(
-                "[TextFinder plugin] Looking for pattern '"
+                "[Text Finder] Looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the files at "
                         + "'"
@@ -207,9 +207,9 @@ public class TextFinderPublisherPipelineTest {
                                 + "', succeedIfFound: true, alsoCheckConsoleOutput: true}\n"));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
-        rule.assertLogContains("[TextFinder plugin] Scanning console output...", build);
+        rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
-                "[TextFinder plugin] Finished looking for pattern '"
+                "[Text Finder] Finished looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);
@@ -232,9 +232,9 @@ public class TextFinderPublisherPipelineTest {
                                 + "', alsoCheckConsoleOutput: true}\n"));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
-        rule.assertLogContains("[TextFinder plugin] Scanning console output...", build);
+        rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
-                "[TextFinder plugin] Finished looking for pattern '"
+                "[Text Finder] Finished looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);
@@ -257,9 +257,9 @@ public class TextFinderPublisherPipelineTest {
                                 + "', unstableIfFound: true, alsoCheckConsoleOutput: true}\n"));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
-        rule.assertLogContains("[TextFinder plugin] Scanning console output...", build);
+        rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
-                "[TextFinder plugin] Finished looking for pattern '"
+                "[Text Finder] Finished looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);
@@ -282,9 +282,9 @@ public class TextFinderPublisherPipelineTest {
                                 + "', notBuiltIfFound: true, alsoCheckConsoleOutput: true}\n"));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
-        rule.assertLogContains("[TextFinder plugin] Scanning console output...", build);
+        rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
-                "[TextFinder plugin] Finished looking for pattern '"
+                "[Text Finder] Finished looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);
@@ -302,9 +302,9 @@ public class TextFinderPublisherPipelineTest {
                                 + "', alsoCheckConsoleOutput: true}\n"));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
-        rule.assertLogContains("[TextFinder plugin] Scanning console output...", build);
+        rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
-                "[TextFinder plugin] Finished looking for pattern '"
+                "[Text Finder] Finished looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);


### PR DESCRIPTION
There are a variety of conventions in use for the naming of this plugin, including "TextFinder", "Text-finder", "Jenkins Text Finder", etc.

Per the [naming conventions](https://jenkins.io/doc/developer/publishing/style-guides/#plugin-naming-convention) section of the Jenkins plugin developer documentation:

> Including _Jenkins_ or _Plugin_ in the name to indicate that it is a plugin for Jenkins is redundant and discouraged, and these terms may be stripped from the name in some cases to ensure consistency in lists, and to shorten the name.

Here we standardize on "Text Finder".