### PR TITLE
Add dependencyManagement section of POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,12 +61,16 @@
         </plugins>
     </build>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jenkins-ci</groupId>
+                <artifactId>symbol-annotation</artifactId>
+                <version>1.3</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-            <version>1.3</version>
-        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>


### PR DESCRIPTION
The `structs` dependency wasn't a direct dependency but rather just added to satisfy the Maven upper bounds check. This more properly belongs in a `dependencyManagement` section.