### PR TITLE
[JENKINS-54128] Avoid calling Run.getLogFile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,6 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(configurations: [
+  [ platform: "linux", jdk: "8", jenkins: null ],
+  [ platform: "windows", jdk: "8", jenkins: null ],
+  [ platform: "linux", jdk: "8", jenkins: "2.164.1", javaLevel: "8" ],
+  [ platform: "windows", jdk: "8", jenkins: "2.164.1", javaLevel: "8" ]
+])

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <revision>1.12</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.121.1</jenkins.version>
         <java.level>8</java.level>
     </properties>
 
@@ -68,31 +68,49 @@
                 <artifactId>symbol-annotation</artifactId>
                 <version>1.3</version>
             </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-step-api</artifactId>
+                <version>2.18</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-api</artifactId>
+            <version>2.33</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.1</version>
+            <version>2.15</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.10</version>
+            <version>2.58</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.4</version>
+            <version>2.26</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.4</version>
+            <version>2.31</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-support</artifactId>
+            <version>2.21</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/hudson/plugins/textfinder/TestUtils.java
+++ b/src/test/java/hudson/plugins/textfinder/TestUtils.java
@@ -1,0 +1,59 @@
+package hudson.plugins.textfinder;
+
+import static org.junit.Assert.assertNotNull;
+
+import hudson.Functions;
+import hudson.model.Run;
+import java.io.File;
+import java.io.IOException;
+import org.jenkinsci.plugins.workflow.actions.WorkspaceAction;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/** Utilities for testing Text Finder */
+public class TestUtils {
+
+    private static void assertContainsMatch(
+            String header, String text, JenkinsRule rule, Run<?, ?> build, boolean isShell)
+            throws IOException {
+        String prompt;
+        if (isShell) {
+            prompt = Functions.isWindows() ? ">" : "+ ";
+        } else {
+            prompt = "";
+        }
+        rule.assertLogContains(String.format("%s%s%s", header, prompt, text), build);
+    }
+
+    public static void assertConsoleContainsMatch(
+            String text, JenkinsRule rule, Run<?, ?> build, boolean isShell) throws IOException {
+        assertContainsMatch("", text, rule, build, isShell);
+    }
+
+    public static void assertFileContainsMatch(
+            File file, String text, JenkinsRule rule, Run<?, ?> build, boolean isShell)
+            throws IOException {
+        assertContainsMatch(
+                String.format("%s:%s", file, System.getProperty("line.separator")),
+                text,
+                rule,
+                build,
+                isShell);
+    }
+
+    public static File getWorkspace(WorkflowRun build) {
+        FlowExecution execution = build.getExecution();
+        assertNotNull(execution);
+        FlowGraphWalker walker = new FlowGraphWalker(execution);
+        for (FlowNode node : walker) {
+            WorkspaceAction action = node.getAction(WorkspaceAction.class);
+            if (action != null) {
+                return new File(action.getWorkspace().getRemote());
+            }
+        }
+        throw new IllegalStateException("Failed to find workspace");
+    }
+}

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherAgentTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherAgentTest.java
@@ -1,16 +1,9 @@
 package hudson.plugins.textfinder;
 
-import hudson.Functions;
 import hudson.model.Result;
 import hudson.slaves.DumbSlave;
 import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import org.jenkinsci.plugins.workflow.actions.WorkspaceAction;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
-import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
-import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Rule;
@@ -24,61 +17,46 @@ public class TextFinderPublisherAgentTest {
 
     @Rule public JenkinsRule rule = new JenkinsRule();
 
-    private void assertLogContainsMatch(File file, String text, WorkflowRun build, boolean isShell)
-            throws IOException {
-        String prompt;
-        if (isShell) {
-            prompt = Functions.isWindows() ? ">" : "+ ";
-        } else {
-            prompt = "";
-        }
-        rule.assertLogContains(
-                String.format(
-                        "%s:%s%s%s", file, System.getProperty("line.separator"), prompt, text),
-                build);
-    }
-
-    private File getWorkspace(WorkflowRun build) {
-        FlowGraphWalker walker = new FlowGraphWalker(build.getExecution());
-        List<WorkspaceAction> actions = new ArrayList<>();
-        for (FlowNode node : walker) {
-            WorkspaceAction action = node.getAction(WorkspaceAction.class);
-            if (action != null) {
-                return new File(action.getWorkspace().getRemote());
-            }
-        }
-        throw new IllegalStateException("Failed to find workspace");
-    }
-
     @Test
     public void failureIfFoundInFileOnAgent() throws Exception {
         DumbSlave agent = rule.createOnlineSlave();
-        WorkflowJob project = rule.createProject(WorkflowJob.class, "pipeline");
+        WorkflowJob project = rule.createProject(WorkflowJob.class);
         project.setDefinition(
                 new CpsFlowDefinition(
                         String.format(
-                                "node('%s') {writeFile file: 'out.txt', text: 'foobar'}\n"
-                                        + "node('%s') {findText regexp: 'foobar', fileSet: 'out.txt'}\n",
-                                agent.getNodeName(), agent.getNodeName())));
+                                "node('%s') {\n"
+                                        + "  writeFile file: 'out.txt', text: 'foobar'\n"
+                                        + "  findText regexp: 'foobar', fileSet: 'out.txt'\n"
+                                        + "}\n",
+                                agent.getNodeName()),
+                        true));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains(
                 "[Text Finder] Looking for pattern " + "'" + UNIQUE_TEXT + "'" + " in the files at",
                 build);
-        assertLogContainsMatch(new File(getWorkspace(build), "out.txt"), UNIQUE_TEXT, build, false);
+        TestUtils.assertFileContainsMatch(
+                new File(TestUtils.getWorkspace(build), "out.txt"),
+                UNIQUE_TEXT,
+                rule,
+                build,
+                false);
         rule.assertBuildStatus(Result.FAILURE, build);
     }
 
     @Test
     public void failureIfFoundInConsoleOnAgent() throws Exception {
         DumbSlave agent = rule.createOnlineSlave();
-        WorkflowJob project = rule.createProject(WorkflowJob.class, "pipeline");
+        WorkflowJob project = rule.createProject(WorkflowJob.class);
         project.setDefinition(
                 new CpsFlowDefinition(
                         String.format(
-                                "node('%s') {isUnix() ? sh('echo foobar') : bat(\"prompt \\$G\\r\\necho foobar\")}\n"
-                                        + "node('%s') {findText regexp: 'foobar', alsoCheckConsoleOutput: true}\n",
-                                agent.getNodeName(), agent.getNodeName())));
+                                "node('%s') {\n"
+                                        + "  isUnix() ? sh('echo foobar') : bat(\"prompt \\$G\\r\\necho foobar\")\n"
+                                        + "  findText regexp: 'foobar', alsoCheckConsoleOutput: true\n"
+                                        + "}\n",
+                                agent.getNodeName()),
+                        true));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
@@ -87,7 +65,7 @@ public class TextFinderPublisherAgentTest {
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);
-        assertLogContainsMatch(build.getLogFile(), ECHO_UNIQUE_TEXT, build, true);
+        TestUtils.assertConsoleContainsMatch(ECHO_UNIQUE_TEXT, rule, build, true);
         rule.assertBuildStatus(Result.FAILURE, build);
     }
 }

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
@@ -13,8 +13,6 @@ import hudson.model.Result;
 import hudson.tasks.BatchFile;
 import hudson.tasks.CommandInterpreter;
 import hudson.tasks.Shell;
-import java.io.File;
-import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -25,20 +23,6 @@ public class TextFinderPublisherFreestyleTest {
     private static final String ECHO_UNIQUE_TEXT = "echo " + UNIQUE_TEXT;
 
     @Rule public JenkinsRule rule = new JenkinsRule();
-
-    private void assertLogContainsMatch(
-            File file, String text, FreeStyleBuild build, boolean isShell) throws IOException {
-        String prompt;
-        if (isShell) {
-            prompt = Functions.isWindows() ? ">" : "+ ";
-        } else {
-            prompt = "";
-        }
-        rule.assertLogContains(
-                String.format(
-                        "%s:%s%s%s", file, System.getProperty("line.separator"), prompt, text),
-                build);
-    }
 
     @Test
     public void successIfFoundInConsole() throws Exception {
@@ -52,16 +36,14 @@ public class TextFinderPublisherFreestyleTest {
         textFinder.setSucceedIfFound(true);
         textFinder.setAlsoCheckConsoleOutput(true);
         project.getPublishersList().add(textFinder);
-        FreeStyleBuild build = project.scheduleBuild2(0).get();
-        rule.waitForCompletion(build);
+        FreeStyleBuild build = rule.buildAndAssertSuccess(project);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
                 "[Text Finder] Finished looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);
-        assertLogContainsMatch(build.getLogFile(), ECHO_UNIQUE_TEXT, build, true);
-        rule.assertBuildStatus(Result.SUCCESS, build);
+        TestUtils.assertConsoleContainsMatch(ECHO_UNIQUE_TEXT, rule, build, true);
     }
 
     @Test
@@ -83,7 +65,7 @@ public class TextFinderPublisherFreestyleTest {
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);
-        assertLogContainsMatch(build.getLogFile(), ECHO_UNIQUE_TEXT, build, true);
+        TestUtils.assertConsoleContainsMatch(ECHO_UNIQUE_TEXT, rule, build, true);
         rule.assertBuildStatus(Result.FAILURE, build);
     }
 
@@ -107,7 +89,7 @@ public class TextFinderPublisherFreestyleTest {
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);
-        assertLogContainsMatch(build.getLogFile(), ECHO_UNIQUE_TEXT, build, true);
+        TestUtils.assertConsoleContainsMatch(ECHO_UNIQUE_TEXT, rule, build, true);
         rule.assertBuildStatus(Result.UNSTABLE, build);
     }
 

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
@@ -1,15 +1,8 @@
 package hudson.plugins.textfinder;
 
-import hudson.Functions;
 import hudson.model.Result;
 import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import org.jenkinsci.plugins.workflow.actions.WorkspaceAction;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
-import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
-import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Rule;
@@ -24,49 +17,25 @@ public class TextFinderPublisherPipelineTest {
 
     @Rule public JenkinsRule rule = new JenkinsRule();
 
-    private void assertLogContainsMatch(File file, String text, WorkflowRun build, boolean isShell)
-            throws IOException {
-        String prompt;
-        if (isShell) {
-            prompt = Functions.isWindows() ? ">" : "+ ";
-        } else {
-            prompt = "";
-        }
-        rule.assertLogContains(
-                String.format(
-                        "%s:%s%s%s", file, System.getProperty("line.separator"), prompt, text),
-                build);
-    }
-
-    private File getWorkspace(WorkflowRun build) {
-        FlowGraphWalker walker = new FlowGraphWalker(build.getExecution());
-        List<WorkspaceAction> actions = new ArrayList<>();
-        for (FlowNode node : walker) {
-            WorkspaceAction action = node.getAction(WorkspaceAction.class);
-            if (action != null) {
-                return new File(action.getWorkspace().getRemote());
-            }
-        }
-        throw new IllegalStateException("Failed to find workspace");
-    }
-
     @Test
     public void successIfFoundInFile() throws Exception {
-        WorkflowJob project = rule.createProject(WorkflowJob.class, "pipeline");
+        WorkflowJob project = rule.createProject(WorkflowJob.class);
         project.setDefinition(
                 new CpsFlowDefinition(
-                        "node {writeFile file: '"
+                        "node {\n"
+                                + "  writeFile file: '"
                                 + fileSet
                                 + "', text: '"
                                 + UNIQUE_TEXT
-                                + "'}\n"
-                                + "node {findText regexp: '"
+                                + "'\n"
+                                + "  findText regexp: '"
                                 + UNIQUE_TEXT
                                 + "', fileSet: '"
                                 + fileSet
-                                + "', succeedIfFound: true}\n"));
-        WorkflowRun build = project.scheduleBuild2(0).get();
-        rule.waitForCompletion(build);
+                                + "', succeedIfFound: true\n"
+                                + "}\n",
+                        true));
+        WorkflowRun build = rule.buildAndAssertSuccess(project);
         rule.assertLogContains(
                 "[Text Finder] Looking for pattern '"
                         + UNIQUE_TEXT
@@ -75,25 +44,28 @@ public class TextFinderPublisherPipelineTest {
                         + fileSet
                         + "'",
                 build);
-        assertLogContainsMatch(new File(getWorkspace(build), fileSet), UNIQUE_TEXT, build, false);
-        rule.assertBuildStatus(Result.SUCCESS, build);
+        TestUtils.assertFileContainsMatch(
+                new File(TestUtils.getWorkspace(build), fileSet), UNIQUE_TEXT, rule, build, false);
     }
 
     @Test
     public void failureIfFoundInFile() throws Exception {
-        WorkflowJob project = rule.createProject(WorkflowJob.class, "pipeline");
+        WorkflowJob project = rule.createProject(WorkflowJob.class);
         project.setDefinition(
                 new CpsFlowDefinition(
-                        "node {writeFile file: '"
+                        "node {\n"
+                                + "  writeFile file: '"
                                 + fileSet
                                 + "', text: '"
                                 + UNIQUE_TEXT
-                                + "'}\n"
-                                + "node {findText regexp: '"
+                                + "'\n"
+                                + "  findText regexp: '"
                                 + UNIQUE_TEXT
                                 + "', fileSet: '"
                                 + fileSet
-                                + "'}\n"));
+                                + "'\n"
+                                + "}\n",
+                        true));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains(
@@ -104,25 +76,29 @@ public class TextFinderPublisherPipelineTest {
                         + fileSet
                         + "'",
                 build);
-        assertLogContainsMatch(new File(getWorkspace(build), fileSet), UNIQUE_TEXT, build, false);
+        TestUtils.assertFileContainsMatch(
+                new File(TestUtils.getWorkspace(build), fileSet), UNIQUE_TEXT, rule, build, false);
         rule.assertBuildStatus(Result.FAILURE, build);
     }
 
     @Test
     public void unstableIfFoundInFile() throws Exception {
-        WorkflowJob project = rule.createProject(WorkflowJob.class, "pipeline");
+        WorkflowJob project = rule.createProject(WorkflowJob.class);
         project.setDefinition(
                 new CpsFlowDefinition(
-                        "node {writeFile file: '"
+                        "node {\n"
+                                + "  writeFile file: '"
                                 + fileSet
                                 + "', text: '"
                                 + UNIQUE_TEXT
-                                + "'}\n"
-                                + "node {findText regexp: '"
+                                + "'\n"
+                                + "  findText regexp: '"
                                 + UNIQUE_TEXT
                                 + "', fileSet: '"
                                 + fileSet
-                                + "', unstableIfFound: true}\n"));
+                                + "', unstableIfFound: true\n"
+                                + "}\n",
+                        true));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains(
@@ -133,25 +109,29 @@ public class TextFinderPublisherPipelineTest {
                         + fileSet
                         + "'",
                 build);
-        assertLogContainsMatch(new File(getWorkspace(build), fileSet), UNIQUE_TEXT, build, false);
+        TestUtils.assertFileContainsMatch(
+                new File(TestUtils.getWorkspace(build), fileSet), UNIQUE_TEXT, rule, build, false);
         rule.assertBuildStatus(Result.UNSTABLE, build);
     }
 
     @Test
     public void notBuiltIfFoundInFile() throws Exception {
-        WorkflowJob project = rule.createProject(WorkflowJob.class, "pipeline");
+        WorkflowJob project = rule.createProject(WorkflowJob.class);
         project.setDefinition(
                 new CpsFlowDefinition(
-                        "node {writeFile file: '"
+                        "node {\n"
+                                + "  writeFile file: '"
                                 + fileSet
                                 + "', text: '"
                                 + UNIQUE_TEXT
-                                + "'}\n"
-                                + "node {findText regexp: '"
+                                + "'\n"
+                                + "  findText regexp: '"
                                 + UNIQUE_TEXT
                                 + "', fileSet: '"
                                 + fileSet
-                                + "', notBuiltIfFound: true}\n"));
+                                + "', notBuiltIfFound: true\n"
+                                + "}\n",
+                        true));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains(
@@ -162,25 +142,28 @@ public class TextFinderPublisherPipelineTest {
                         + fileSet
                         + "'",
                 build);
-        assertLogContainsMatch(new File(getWorkspace(build), fileSet), UNIQUE_TEXT, build, false);
+        TestUtils.assertFileContainsMatch(
+                new File(TestUtils.getWorkspace(build), fileSet), UNIQUE_TEXT, rule, build, false);
         rule.assertBuildStatus(Result.NOT_BUILT, build);
     }
 
     @Test
     public void notFoundInFile() throws Exception {
-        WorkflowJob project = rule.createProject(WorkflowJob.class, "pipeline");
+        WorkflowJob project = rule.createProject(WorkflowJob.class);
         project.setDefinition(
                 new CpsFlowDefinition(
-                        "node {writeFile file: '"
+                        "node {\n"
+                                + "  writeFile file: '"
                                 + fileSet
-                                + "', text: 'foobaz'}\n"
-                                + "node {findText regexp: '"
+                                + "', text: 'foobaz'\n"
+                                + "  findText regexp: '"
                                 + UNIQUE_TEXT
                                 + "', fileSet: '"
                                 + fileSet
-                                + "'}\n"));
-        WorkflowRun build = project.scheduleBuild2(0).get();
-        rule.waitForCompletion(build);
+                                + "'\n"
+                                + "}\n",
+                        true));
+        WorkflowRun build = rule.buildAndAssertSuccess(project);
         rule.assertLogContains(
                 "[Text Finder] Looking for pattern '"
                         + UNIQUE_TEXT
@@ -189,47 +172,50 @@ public class TextFinderPublisherPipelineTest {
                         + fileSet
                         + "'",
                 build);
-        rule.assertBuildStatus(Result.SUCCESS, build);
     }
 
     @Test
     public void successIfFoundInConsole() throws Exception {
-        WorkflowJob project = rule.createProject(WorkflowJob.class, "pipeline");
+        WorkflowJob project = rule.createProject(WorkflowJob.class);
         project.setDefinition(
                 new CpsFlowDefinition(
-                        "node {isUnix() ? sh('"
+                        "node {\n"
+                                + "  isUnix() ? sh('"
                                 + ECHO_UNIQUE_TEXT
                                 + "') : bat(\"prompt \\$G\\r\\n"
                                 + ECHO_UNIQUE_TEXT
-                                + "\")}\n"
-                                + "node {findText regexp: '"
+                                + "\")\n"
+                                + "  findText regexp: '"
                                 + UNIQUE_TEXT
-                                + "', succeedIfFound: true, alsoCheckConsoleOutput: true}\n"));
-        WorkflowRun build = project.scheduleBuild2(0).get();
-        rule.waitForCompletion(build);
+                                + "', succeedIfFound: true, alsoCheckConsoleOutput: true\n"
+                                + "}\n",
+                        true));
+        WorkflowRun build = rule.buildAndAssertSuccess(project);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
                 "[Text Finder] Finished looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);
-        assertLogContainsMatch(build.getLogFile(), ECHO_UNIQUE_TEXT, build, true);
-        rule.assertBuildStatus(Result.SUCCESS, build);
+        TestUtils.assertConsoleContainsMatch(ECHO_UNIQUE_TEXT, rule, build, true);
     }
 
     @Test
     public void failureIfFoundInConsole() throws Exception {
-        WorkflowJob project = rule.createProject(WorkflowJob.class, "pipeline");
+        WorkflowJob project = rule.createProject(WorkflowJob.class);
         project.setDefinition(
                 new CpsFlowDefinition(
-                        "node {isUnix() ? sh('"
+                        "node {\n"
+                                + "  isUnix() ? sh('"
                                 + ECHO_UNIQUE_TEXT
                                 + "') : bat(\"prompt \\$G\\r\\n"
                                 + ECHO_UNIQUE_TEXT
-                                + "\")}\n"
-                                + "node {findText regexp: '"
+                                + "\")\n"
+                                + "  findText regexp: '"
                                 + UNIQUE_TEXT
-                                + "', alsoCheckConsoleOutput: true}\n"));
+                                + "', alsoCheckConsoleOutput: true\n"
+                                + "}\n",
+                        true));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
@@ -238,23 +224,26 @@ public class TextFinderPublisherPipelineTest {
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);
-        assertLogContainsMatch(build.getLogFile(), ECHO_UNIQUE_TEXT, build, true);
+        TestUtils.assertConsoleContainsMatch(ECHO_UNIQUE_TEXT, rule, build, true);
         rule.assertBuildStatus(Result.FAILURE, build);
     }
 
     @Test
     public void unstableIfFoundInConsole() throws Exception {
-        WorkflowJob project = rule.createProject(WorkflowJob.class, "pipeline");
+        WorkflowJob project = rule.createProject(WorkflowJob.class);
         project.setDefinition(
                 new CpsFlowDefinition(
-                        "node {isUnix() ? sh('"
+                        "node {\n"
+                                + "  isUnix() ? sh('"
                                 + ECHO_UNIQUE_TEXT
                                 + "') : bat(\"prompt \\$G\\r\\n"
                                 + ECHO_UNIQUE_TEXT
-                                + "\")}\n"
-                                + "node {findText regexp: '"
+                                + "\")\n"
+                                + "  findText regexp: '"
                                 + UNIQUE_TEXT
-                                + "', unstableIfFound: true, alsoCheckConsoleOutput: true}\n"));
+                                + "', unstableIfFound: true, alsoCheckConsoleOutput: true\n"
+                                + "}\n",
+                        true));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
@@ -263,23 +252,26 @@ public class TextFinderPublisherPipelineTest {
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);
-        assertLogContainsMatch(build.getLogFile(), ECHO_UNIQUE_TEXT, build, true);
+        TestUtils.assertConsoleContainsMatch(ECHO_UNIQUE_TEXT, rule, build, true);
         rule.assertBuildStatus(Result.UNSTABLE, build);
     }
 
     @Test
     public void notBuiltIfFoundInConsole() throws Exception {
-        WorkflowJob project = rule.createProject(WorkflowJob.class, "pipeline");
+        WorkflowJob project = rule.createProject(WorkflowJob.class);
         project.setDefinition(
                 new CpsFlowDefinition(
-                        "node {isUnix() ? sh('"
+                        "node {\n"
+                                + "  isUnix() ? sh('"
                                 + ECHO_UNIQUE_TEXT
                                 + "') : bat(\"prompt \\$G\\r\\n"
                                 + ECHO_UNIQUE_TEXT
-                                + "\")}\n"
-                                + "node {findText regexp: '"
+                                + "\")\n"
+                                + "  findText regexp: '"
                                 + UNIQUE_TEXT
-                                + "', notBuiltIfFound: true, alsoCheckConsoleOutput: true}\n"));
+                                + "', notBuiltIfFound: true, alsoCheckConsoleOutput: true\n"
+                                + "}\n",
+                        true));
         WorkflowRun build = project.scheduleBuild2(0).get();
         rule.waitForCompletion(build);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
@@ -288,26 +280,27 @@ public class TextFinderPublisherPipelineTest {
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);
-        assertLogContainsMatch(build.getLogFile(), ECHO_UNIQUE_TEXT, build, true);
+        TestUtils.assertConsoleContainsMatch(ECHO_UNIQUE_TEXT, rule, build, true);
         rule.assertBuildStatus(Result.NOT_BUILT, build);
     }
 
     @Test
     public void notFoundInConsole() throws Exception {
-        WorkflowJob project = rule.createProject(WorkflowJob.class, "pipeline");
+        WorkflowJob project = rule.createProject(WorkflowJob.class);
         project.setDefinition(
                 new CpsFlowDefinition(
-                        "node {findText regexp: '"
+                        "node {\n"
+                                + "  findText regexp: '"
                                 + UNIQUE_TEXT
-                                + "', alsoCheckConsoleOutput: true}\n"));
-        WorkflowRun build = project.scheduleBuild2(0).get();
-        rule.waitForCompletion(build);
+                                + "', alsoCheckConsoleOutput: true\n"
+                                + "}\n",
+                        true));
+        WorkflowRun build = rule.buildAndAssertSuccess(project);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
                 "[Text Finder] Finished looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);
-        rule.assertBuildStatus(Result.SUCCESS, build);
     }
 }


### PR DESCRIPTION
[JENKINS-54128](https://issues.jenkins-ci.org/browse/JENKINS-54128) for this plugin. Follows closely the implementation done in jenkinsci/groovy-postbuild-plugin#40.