### PR TITLE
Plugin metadata updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,36 +1,33 @@
-## Changelog
+# Changelog
 
-### 1.12 
+* All notable changes prior to 1.13 are documented in this changelog.
+* Release notes for versions >=1.13 can be found on the [GitHub releases page](https://github.com/jenkinsci/text-finder-plugin/releases).
+
+### 1.12
 
 Release date: 2019-08-01
 
-- Documentation updates: Improve writing of plugin description
-  ([PR 28](https://github.com/jenkinsci/text-finder-plugin/pull/28))
-- Internal: Text Finder now fully supports [JEP-210](https://github.com/jenkinsci/jep/tree/master/jep/210) and requires Jenkins 2.121 LTS or greater and JEP 210-compatible versions of Pipeline plugins.
-  - Avoid calling Run.getLogFile 
-  ([JENKINS-54128](https://issues.jenkins-ci.org/browse/JENKINS-54128))
-  ([PR 46](https://github.com/jenkinsci/text-finder-plugin/pull/46))
-  - Make naming consistent ([PR 29](https://github.com/jenkinsci/text-finder-plugin/pull/29))
-- Tests: Add UI testing ([PR 41](https://github.com/jenkinsci/text-finder-plugin/pull/41))
+- Documentation updates: Improve writing of plugin description ([\#28](https://github.com/jenkinsci/text-finder-plugin/pull/28))
+- Internal: Text Finder now fully supports [JEP-210](https://github.com/jenkinsci/jep/tree/master/jep/210) and requires Jenkins 2.121 LTS or greater and JEP 210-compatible versions of Pipeline plugins
+
+- \[[JENKINS-54128](https://issues.jenkins-ci.org/browse/JENKINS-54128)\] Avoid calling `Run#getLogFile` ([\#46](https://github.com/jenkinsci/text-finder-plugin/pull/46))
+- Make naming consistent ([\#29](https://github.com/jenkinsci/text-finder-plugin/pull/29))
+- Add UI testing ([\#41](https://github.com/jenkinsci/text-finder-plugin/pull/41))
 
 ### 1.11
 
 Release date: 2019-06-01
 
-- Add pipeline support
-  ([PR 12](https://github.com/jenkinsci/text-finder-plugin/pull/12))
-- Add option to set build as not built
-  ([PR 16](https://github.com/jenkinsci/text-finder-plugin/pull/16))
-- Better log output to console
-  ([PR 21](https://github.com/jenkinsci/text-finder-plugin/pull/21))
+- Add Pipeline support ([\#12](https://github.com/jenkinsci/text-finder-plugin/pull/12))
+- Add option to set build as not built ([\#16](https://github.com/jenkinsci/text-finder-plugin/pull/16))
+- Better log output to console ([\#21](https://github.com/jenkinsci/text-finder-plugin/pull/21))
 
 ### 1.10
 
 Release date: 2014-01-31
 
-- No longer blocking concurrent builds.
-  ([JENKINS-17507](https://issues.jenkins-ci.org/browse/JENKINS-17507))
-- Cleaner config UI using help buttons
+- \[[JENKINS-17507](https://issues.jenkins-ci.org/browse/JENKINS-17507)\] Do not block concurrent builds
+- Cleaner configuration UI using help buttons
 - Japanese translation
 
 ### 1.9
@@ -49,17 +46,14 @@ Release date: 2010-02-06
 
 Release date: 2009-05-04
 
-- Fixed a file handle leak
-  ([JENKINS-3613](https://issues.jenkins-ci.org/browse/JENKINS-3613))
+- \[[JENKINS-3613](https://issues.jenkins-ci.org/browse/JENKINS-3613)\] Fix a file handle leak
 
 ### 1.6
 
 Release date: 2008-11-06
 
-- Modified to work with all job types, including Maven2 jobs.
+- Modify to work with all job types, including Maven 2 jobs
 
 ### 1.5
 
-- Added "Unstable if found" configuration option.  Use this option to
-  set build unstable instead of failing the build.  Default is off
-  (previous behavior).
+- Add "Unstable if found" configuration option. Use this option to set build unstable instead of failing the build. Default is off (previous behavior).

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,12 @@
 buildPlugin(configurations: [
-  [ platform: "linux", jdk: "8", jenkins: null ],
-  [ platform: "windows", jdk: "8", jenkins: null ],
-  [ platform: "linux", jdk: "8", jenkins: "2.164.1", javaLevel: "8" ],
-  [ platform: "windows", jdk: "8", jenkins: "2.164.1", javaLevel: "8" ]
+  // Test the long-term support end of the compatibility spectrum (i.e., the minimum required
+  // Jenkins version).
+  [ platform: 'linux', jdk: '8', jenkins: null ],
+
+  // Test the common case (i.e., a recent LTS release) on both Linux and Windows.
+  [ platform: 'linux', jdk: '8', jenkins: '2.222.4', javaLevel: '8' ],
+  [ platform: 'windows', jdk: '8', jenkins: '2.222.4', javaLevel: '8' ],
+
+  // Test the bleeding edge of the compatibility spectrum (i.e., the latest supported Java runtime).
+  [ platform: 'linux', jdk: '11', jenkins: '2.222.4', javaLevel: '8' ],
 ])

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-# Text Finder
+# Text Finder Plugin
 
 [![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/text-finder-plugin/master)](https://ci.jenkins.io/job/Plugins/job/text-finder-plugin/job/master/)
-[![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/text-finder.svg)](https://plugins.jenkins.io/text-finder)
-[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/text-finder.svg)](https://plugins.jenkins.io/text-finder)
+[![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/text-finder.svg)](https://plugins.jenkins.io/text-finder/)
+[![GitHub Releases](https://img.shields.io/github/release/jenkinsci/text-finder-plugin.svg?label=changelog)](https://github.com/jenkinsci/text-finder-plugin/releases)
+[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/text-finder.svg?color=blue)](https://plugins.jenkins.io/text-finder/)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=jenkinsci/text-finder-plugin)](https://dependabot.com)
 
 This plugin lets you search for some text using regular expressions in a
 set of files or the console log. Once a match is found, you can
-downgrade a successful build to a status of 
+downgrade a successful build to a status of
 [unstable](https://javadoc.jenkins-ci.org/hudson/model/Result.html#UNSTABLE),
 [failure](https://javadoc.jenkins-ci.org/hudson/model/Result.html#FAILURE),
 or [not built](https://javadoc.jenkins-ci.org/hudson/model/Result.html#NOT_BUILT).

--- a/pom.xml
+++ b/pom.xml
@@ -48,26 +48,6 @@
       <tag>${scmTag}</tag>
   </scm>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>com.coveo</groupId>
-                <artifactId>fmt-maven-plugin</artifactId>
-                <version>2.9</version>
-                <configuration>
-                    <style>aosp</style>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,12 +14,12 @@
     <name>Text Finder</name>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <licenses>
-     <license>
-       <name>The MIT License (MIT)</name>
-       <url>http://opensource.org/licenses/MIT</url>
-       <distribution>repo</distribution>
-     </license>
-   </licenses>
+        <license>
+            <name>The MIT License (MIT)</name>
+            <url>http://opensource.org/licenses/MIT</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
     <properties>
         <revision>1.13</revision>
         <changelist>-SNAPSHOT</changelist>
@@ -45,8 +45,8 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>${scmTag}</tag>
-  </scm>
+        <tag>${scmTag}</tag>
+    </scm>
 
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -51,14 +51,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.jenkins-ci</groupId>
-                <artifactId>symbol-annotation</artifactId>
-                <version>1.3</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins.workflow</groupId>
-                <artifactId>workflow-step-api</artifactId>
-                <version>2.18</version>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.164.x</artifactId>
+                <version>10</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -67,37 +64,31 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.33</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.15</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.58</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.26</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.31</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.21</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.48</version>
+        <version>4.2</version>
         <relativePath />
     </parent>
 
@@ -23,7 +23,7 @@
     <properties>
         <revision>1.13</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.121.1</jenkins.version>
+        <jenkins.version>2.164.3</jenkins.version>
         <java.level>8</java.level>
     </properties>
 

--- a/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
@@ -18,6 +18,18 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 import hudson.util.FormValidation;
+
+import jenkins.MasterToSlaveFileCallable;
+import jenkins.tasks.SimpleBuildStep;
+
+import org.apache.tools.ant.DirectoryScanner;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.types.FileSet;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -31,16 +43,8 @@ import java.nio.charset.Charset;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+
 import javax.servlet.ServletException;
-import jenkins.MasterToSlaveFileCallable;
-import jenkins.tasks.SimpleBuildStep;
-import org.apache.tools.ant.DirectoryScanner;
-import org.apache.tools.ant.Project;
-import org.apache.tools.ant.types.FileSet;
-import org.jenkinsci.Symbol;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
-import org.kohsuke.stapler.QueryParameter;
 
 /**
  * Text Finder plugin for Jenkins. Search in the workspace using a regular expression and determine

--- a/src/test/java/hudson/plugins/textfinder/TestUtils.java
+++ b/src/test/java/hudson/plugins/textfinder/TestUtils.java
@@ -4,14 +4,16 @@ import static org.junit.Assert.assertNotNull;
 
 import hudson.Functions;
 import hudson.model.Run;
-import java.io.File;
-import java.io.IOException;
+
 import org.jenkinsci.plugins.workflow.actions.WorkspaceAction;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.File;
+import java.io.IOException;
 
 /** Utilities for testing Text Finder */
 public class TestUtils {

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherAgentTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherAgentTest.java
@@ -2,13 +2,15 @@ package hudson.plugins.textfinder;
 
 import hudson.model.Result;
 import hudson.slaves.DumbSlave;
-import java.io.File;
+
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.File;
 
 public class TextFinderPublisherAgentTest {
 
@@ -52,9 +54,11 @@ public class TextFinderPublisherAgentTest {
                 new CpsFlowDefinition(
                         String.format(
                                 "node('%s') {\n"
-                                        + "  isUnix() ? sh('echo foobar') : bat(\"prompt \\$G\\r\\necho foobar\")\n"
-                                        + "  findText regexp: 'foobar', alsoCheckConsoleOutput: true\n"
-                                        + "}\n",
+                                    + "  isUnix() ? sh('echo foobar') : bat(\"prompt \\$G\\r"
+                                    + "\\n"
+                                    + "echo foobar\")\n"
+                                    + "  findText regexp: 'foobar', alsoCheckConsoleOutput: true\n"
+                                    + "}\n",
                                 agent.getNodeName()),
                         true));
         WorkflowRun build = project.scheduleBuild2(0).get();

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 import com.gargoylesoftware.htmlunit.WebClientUtil;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
+
 import hudson.Functions;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
@@ -13,6 +14,7 @@ import hudson.model.Result;
 import hudson.tasks.BatchFile;
 import hudson.tasks.CommandInterpreter;
 import hudson.tasks.Shell;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
@@ -1,13 +1,15 @@
 package hudson.plugins.textfinder;
 
 import hudson.model.Result;
-import java.io.File;
+
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.File;
 
 public class TextFinderPublisherPipelineTest {
 


### PR DESCRIPTION
Updates plugin metadata for 2020:

- Use a recent LTS release in the `Jenkinsfile`
- Update the plugin POM to the latest version and switch to the plugin BOM to avoid having to declare test dependency versions
- Fix incorrect XML indentation in `pom.xml`
- Remove the `fmt-maven-plugin` and format the code with the latest version of google-java-format`
- Clean up `CHANGELOG.md` and `README.md`