### PR TITLE
[JENKINS-10126] Text Finder plugin incompatible with Timestamper plugin

### DIFF
--- a/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
@@ -45,8 +45,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import javax.servlet.ServletException;
-
 /**
  * Text Finder plugin for Jenkins. Search in the workspace using a regular expression and determine
  * build outcome based on matches.
@@ -277,11 +275,8 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
          *
          * @param value The expression to check
          * @return The form validation result
-         * @throws IOException For backwards compatibility
-         * @throws ServletException For backwards compatibility
          */
-        public FormValidation doCheckRegexp(@QueryParameter String value)
-                throws IOException, ServletException {
+        public FormValidation doCheckRegexp(@QueryParameter String value) {
             value = fixEmpty(value);
             if (value == null) {
                 return FormValidation.ok(); // not entered yet

--- a/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
@@ -7,6 +7,7 @@ import hudson.FilePath;
 import hudson.Functions;
 import hudson.Launcher;
 import hudson.Util;
+import hudson.console.ConsoleNote;
 import hudson.model.AbstractProject;
 import hudson.model.Result;
 import hudson.model.Run;
@@ -178,16 +179,10 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
     /**
      * Search the given regexp pattern.
      *
-     * @param abortAfterFirstHit true to return immediately as soon as the first hit is found. this
-     *     is necessary when we are scanning the console output, because otherwise we'll loop
-     *     forever.
+     * @param isConsoleLog True if the reader represents a console log (as opposed to a file).
      */
     private static boolean checkPattern(
-            Reader r,
-            Pattern pattern,
-            PrintStream logger,
-            String header,
-            boolean abortAfterFirstHit)
+            Reader r, Pattern pattern, PrintStream logger, String header, boolean isConsoleLog)
             throws IOException {
         boolean logFilename = true;
         boolean foundText = false;
@@ -195,6 +190,13 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
             // Assume default encoding and text files
             String line;
             while ((line = reader.readLine()) != null) {
+                /*
+                 * Strip console logs of their console notes before searching; otherwise, we might
+                 * accidentally match the search string in the encoded console note.
+                 */
+                if (isConsoleLog) {
+                    line = ConsoleNote.removeNotes(line);
+                }
                 Matcher matcher = pattern.matcher(line);
                 if (matcher.find()) {
                     if (logFilename) { // first occurrence
@@ -205,7 +207,11 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
                     }
                     logger.println(line);
                     foundText = true;
-                    if (abortAfterFirstHit) {
+                    /*
+                     * When searching console output, return immediately as soon as the first hit is
+                     * found; otherwise, we'll loop forever.
+                     */
+                    if (isConsoleLog) {
                         return true;
                     }
                 }

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherAgentTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherAgentTest.java
@@ -32,8 +32,7 @@ public class TextFinderPublisherAgentTest {
                                         + "}\n",
                                 agent.getNodeName()),
                         true));
-        WorkflowRun build = project.scheduleBuild2(0).get();
-        rule.waitForCompletion(build);
+        WorkflowRun build = rule.buildAndAssertStatus(Result.FAILURE, project);
         rule.assertLogContains(
                 "[Text Finder] Looking for pattern " + "'" + UNIQUE_TEXT + "'" + " in the files at",
                 build);
@@ -43,7 +42,6 @@ public class TextFinderPublisherAgentTest {
                 rule,
                 build,
                 false);
-        rule.assertBuildStatus(Result.FAILURE, build);
     }
 
     @Test
@@ -61,8 +59,7 @@ public class TextFinderPublisherAgentTest {
                                     + "}\n",
                                 agent.getNodeName()),
                         true));
-        WorkflowRun build = project.scheduleBuild2(0).get();
-        rule.waitForCompletion(build);
+        WorkflowRun build = rule.buildAndAssertStatus(Result.FAILURE, project);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
                 "[Text Finder] Finished looking for pattern '"
@@ -70,6 +67,5 @@ public class TextFinderPublisherAgentTest {
                         + "' in the console output",
                 build);
         TestUtils.assertConsoleContainsMatch(ECHO_UNIQUE_TEXT, rule, build, true);
-        rule.assertBuildStatus(Result.FAILURE, build);
     }
 }

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
@@ -59,8 +59,7 @@ public class TextFinderPublisherFreestyleTest {
         TextFinderPublisher textFinder = new TextFinderPublisher(UNIQUE_TEXT);
         textFinder.setAlsoCheckConsoleOutput(true);
         project.getPublishersList().add(textFinder);
-        FreeStyleBuild build = project.scheduleBuild2(0).get();
-        rule.waitForCompletion(build);
+        FreeStyleBuild build = rule.buildAndAssertStatus(Result.FAILURE, project);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
                 "[Text Finder] Finished looking for pattern '"
@@ -68,7 +67,6 @@ public class TextFinderPublisherFreestyleTest {
                         + "' in the console output",
                 build);
         TestUtils.assertConsoleContainsMatch(ECHO_UNIQUE_TEXT, rule, build, true);
-        rule.assertBuildStatus(Result.FAILURE, build);
     }
 
     @Test
@@ -83,8 +81,7 @@ public class TextFinderPublisherFreestyleTest {
         textFinder.setUnstableIfFound(true);
         textFinder.setAlsoCheckConsoleOutput(true);
         project.getPublishersList().add(textFinder);
-        FreeStyleBuild build = project.scheduleBuild2(0).get();
-        rule.waitForCompletion(build);
+        FreeStyleBuild build = rule.buildAndAssertStatus(Result.UNSTABLE, project);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
                 "[Text Finder] Finished looking for pattern '"
@@ -92,7 +89,6 @@ public class TextFinderPublisherFreestyleTest {
                         + "' in the console output",
                 build);
         TestUtils.assertConsoleContainsMatch(ECHO_UNIQUE_TEXT, rule, build, true);
-        rule.assertBuildStatus(Result.UNSTABLE, build);
     }
 
     @Test
@@ -101,15 +97,13 @@ public class TextFinderPublisherFreestyleTest {
         TextFinderPublisher textFinder = new TextFinderPublisher(UNIQUE_TEXT);
         textFinder.setAlsoCheckConsoleOutput(true);
         project.getPublishersList().add(textFinder);
-        FreeStyleBuild build = project.scheduleBuild2(0).get();
-        rule.waitForCompletion(build);
+        FreeStyleBuild build = rule.buildAndAssertSuccess(project);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
                 "[Text Finder] Finished looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);
-        rule.assertBuildStatus(Result.SUCCESS, build);
     }
 
     @Test

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
@@ -68,8 +68,7 @@ public class TextFinderPublisherPipelineTest {
                                 + "'\n"
                                 + "}\n",
                         true));
-        WorkflowRun build = project.scheduleBuild2(0).get();
-        rule.waitForCompletion(build);
+        WorkflowRun build = rule.buildAndAssertStatus(Result.FAILURE, project);
         rule.assertLogContains(
                 "[Text Finder] Looking for pattern '"
                         + UNIQUE_TEXT
@@ -80,7 +79,6 @@ public class TextFinderPublisherPipelineTest {
                 build);
         TestUtils.assertFileContainsMatch(
                 new File(TestUtils.getWorkspace(build), fileSet), UNIQUE_TEXT, rule, build, false);
-        rule.assertBuildStatus(Result.FAILURE, build);
     }
 
     @Test
@@ -101,8 +99,7 @@ public class TextFinderPublisherPipelineTest {
                                 + "', unstableIfFound: true\n"
                                 + "}\n",
                         true));
-        WorkflowRun build = project.scheduleBuild2(0).get();
-        rule.waitForCompletion(build);
+        WorkflowRun build = rule.buildAndAssertStatus(Result.UNSTABLE, project);
         rule.assertLogContains(
                 "[Text Finder] Looking for pattern '"
                         + UNIQUE_TEXT
@@ -113,7 +110,6 @@ public class TextFinderPublisherPipelineTest {
                 build);
         TestUtils.assertFileContainsMatch(
                 new File(TestUtils.getWorkspace(build), fileSet), UNIQUE_TEXT, rule, build, false);
-        rule.assertBuildStatus(Result.UNSTABLE, build);
     }
 
     @Test
@@ -134,8 +130,7 @@ public class TextFinderPublisherPipelineTest {
                                 + "', notBuiltIfFound: true\n"
                                 + "}\n",
                         true));
-        WorkflowRun build = project.scheduleBuild2(0).get();
-        rule.waitForCompletion(build);
+        WorkflowRun build = rule.buildAndAssertStatus(Result.NOT_BUILT, project);
         rule.assertLogContains(
                 "[Text Finder] Looking for pattern '"
                         + UNIQUE_TEXT
@@ -146,7 +141,6 @@ public class TextFinderPublisherPipelineTest {
                 build);
         TestUtils.assertFileContainsMatch(
                 new File(TestUtils.getWorkspace(build), fileSet), UNIQUE_TEXT, rule, build, false);
-        rule.assertBuildStatus(Result.NOT_BUILT, build);
     }
 
     @Test
@@ -218,8 +212,7 @@ public class TextFinderPublisherPipelineTest {
                                 + "', alsoCheckConsoleOutput: true\n"
                                 + "}\n",
                         true));
-        WorkflowRun build = project.scheduleBuild2(0).get();
-        rule.waitForCompletion(build);
+        WorkflowRun build = rule.buildAndAssertStatus(Result.FAILURE, project);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
                 "[Text Finder] Finished looking for pattern '"
@@ -227,7 +220,6 @@ public class TextFinderPublisherPipelineTest {
                         + "' in the console output",
                 build);
         TestUtils.assertConsoleContainsMatch(ECHO_UNIQUE_TEXT, rule, build, true);
-        rule.assertBuildStatus(Result.FAILURE, build);
     }
 
     @Test
@@ -246,8 +238,7 @@ public class TextFinderPublisherPipelineTest {
                                 + "', unstableIfFound: true, alsoCheckConsoleOutput: true\n"
                                 + "}\n",
                         true));
-        WorkflowRun build = project.scheduleBuild2(0).get();
-        rule.waitForCompletion(build);
+        WorkflowRun build = rule.buildAndAssertStatus(Result.UNSTABLE, project);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
                 "[Text Finder] Finished looking for pattern '"
@@ -255,7 +246,6 @@ public class TextFinderPublisherPipelineTest {
                         + "' in the console output",
                 build);
         TestUtils.assertConsoleContainsMatch(ECHO_UNIQUE_TEXT, rule, build, true);
-        rule.assertBuildStatus(Result.UNSTABLE, build);
     }
 
     @Test
@@ -274,8 +264,7 @@ public class TextFinderPublisherPipelineTest {
                                 + "', notBuiltIfFound: true, alsoCheckConsoleOutput: true\n"
                                 + "}\n",
                         true));
-        WorkflowRun build = project.scheduleBuild2(0).get();
-        rule.waitForCompletion(build);
+        WorkflowRun build = rule.buildAndAssertStatus(Result.NOT_BUILT, project);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
                 "[Text Finder] Finished looking for pattern '"
@@ -283,7 +272,6 @@ public class TextFinderPublisherPipelineTest {
                         + "' in the console output",
                 build);
         TestUtils.assertConsoleContainsMatch(ECHO_UNIQUE_TEXT, rule, build, true);
-        rule.assertBuildStatus(Result.NOT_BUILT, build);
     }
 
     @Test


### PR DESCRIPTION
Fixed [JENKINS-10126](https://issues.jenkins-ci.org/browse/JENKINS-10126) by incorporating the patch provided in the bug. It's not trivial to write a test for this case, but based on the presence of similar code in Timestamper, e.g.

https://github.com/jenkinsci/timestamper-plugin/blob/8d0cd64a68eff7cf04fb62e36d0d2436d104e781/src/main/java/hudson/plugins/timestamper/action/TimestampsActionOutput.java#L173

I conclude this is safe.

As a bonus, I cleaned up the tests by using newer Jenkins test harness test methods and removing any unnecessary `throws`.