### PR TITLE
Improvements to tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,12 @@
             <artifactId>workflow-support</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>job-dsl</artifactId>
+            <version>1.77</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
@@ -144,8 +144,6 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
                                 + " in the console output");
             }
 
-            final RemoteOutputStream ros = new RemoteOutputStream(logger);
-
             if (fileSet != null) {
                 logger.println(
                         "[Text Finder] Looking for pattern "
@@ -156,15 +154,18 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
                                 + "'"
                                 + fileSet
                                 + "'");
+                RemoteOutputStream ros = new RemoteOutputStream(logger);
                 foundText |= workspace.act(new FileChecker(ros, fileSet, regexp));
             }
 
             if (foundText != succeedIfFound) {
-                final Result finalResult;
+                Result finalResult;
                 if (notBuiltIfFound) {
                     finalResult = Result.NOT_BUILT;
+                } else if (unstableIfFound) {
+                    finalResult = Result.UNSTABLE;
                 } else {
-                    finalResult = unstableIfFound ? Result.UNSTABLE : Result.FAILURE;
+                    finalResult = Result.FAILURE;
                 }
                 run.setResult(finalResult);
             }

--- a/src/test/java/hudson/plugins/textfinder/TestUtils.java
+++ b/src/test/java/hudson/plugins/textfinder/TestUtils.java
@@ -17,7 +17,9 @@ import java.io.IOException;
 /** Utilities for testing Text Finder */
 public class TestUtils {
 
+    public static final String FILE_SET = "out.txt";
     public static final String PREFIX = ">>> ";
+    public static final String UNIQUE_TEXT = "foobar";
 
     public static void assertFileContainsMatch(
             File file, String text, JenkinsRule rule, Run<?, ?> build) throws IOException {

--- a/src/test/java/hudson/plugins/textfinder/TestUtils.java
+++ b/src/test/java/hudson/plugins/textfinder/TestUtils.java
@@ -2,7 +2,6 @@ package hudson.plugins.textfinder;
 
 import static org.junit.Assert.assertNotNull;
 
-import hudson.Functions;
 import hudson.model.Run;
 
 import org.jenkinsci.plugins.workflow.actions.WorkspaceAction;
@@ -18,32 +17,12 @@ import java.io.IOException;
 /** Utilities for testing Text Finder */
 public class TestUtils {
 
-    private static void assertContainsMatch(
-            String header, String text, JenkinsRule rule, Run<?, ?> build, boolean isShell)
-            throws IOException {
-        String prompt;
-        if (isShell) {
-            prompt = Functions.isWindows() ? ">" : "+ ";
-        } else {
-            prompt = "";
-        }
-        rule.assertLogContains(String.format("%s%s%s", header, prompt, text), build);
-    }
-
-    public static void assertConsoleContainsMatch(
-            String text, JenkinsRule rule, Run<?, ?> build, boolean isShell) throws IOException {
-        assertContainsMatch("", text, rule, build, isShell);
-    }
+    public static final String PREFIX = ">>> ";
 
     public static void assertFileContainsMatch(
-            File file, String text, JenkinsRule rule, Run<?, ?> build, boolean isShell)
-            throws IOException {
-        assertContainsMatch(
-                String.format("%s:%s", file, System.getProperty("line.separator")),
-                text,
-                rule,
-                build,
-                isShell);
+            File file, String text, JenkinsRule rule, Run<?, ?> build) throws IOException {
+        rule.assertLogContains(
+                String.format("%s:%s%s", file, System.getProperty("line.separator"), text), build);
     }
 
     public static File getWorkspace(WorkflowRun build) {

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherAgentTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherAgentTest.java
@@ -15,7 +15,6 @@ import java.io.File;
 public class TextFinderPublisherAgentTest {
 
     private static final String UNIQUE_TEXT = "foobar";
-    private static final String ECHO_UNIQUE_TEXT = "echo " + UNIQUE_TEXT;
 
     @Rule public JenkinsRule rule = new JenkinsRule();
 
@@ -37,11 +36,7 @@ public class TextFinderPublisherAgentTest {
                 "[Text Finder] Looking for pattern " + "'" + UNIQUE_TEXT + "'" + " in the files at",
                 build);
         TestUtils.assertFileContainsMatch(
-                new File(TestUtils.getWorkspace(build), "out.txt"),
-                UNIQUE_TEXT,
-                rule,
-                build,
-                false);
+                new File(TestUtils.getWorkspace(build), "out.txt"), UNIQUE_TEXT, rule, build);
     }
 
     @Test
@@ -52,20 +47,21 @@ public class TextFinderPublisherAgentTest {
                 new CpsFlowDefinition(
                         String.format(
                                 "node('%s') {\n"
-                                    + "  isUnix() ? sh('echo foobar') : bat(\"prompt \\$G\\r"
-                                    + "\\n"
-                                    + "echo foobar\")\n"
-                                    + "  findText regexp: 'foobar', alsoCheckConsoleOutput: true\n"
-                                    + "}\n",
+                                        + "  testEcho '"
+                                        + UNIQUE_TEXT
+                                        + "'\n"
+                                        + "  findText regexp: 'foobar', alsoCheckConsoleOutput:"
+                                        + " true\n"
+                                        + "}\n",
                                 agent.getNodeName()),
                         true));
         WorkflowRun build = rule.buildAndAssertStatus(Result.FAILURE, project);
+        rule.assertLogContains(TestUtils.PREFIX + UNIQUE_TEXT, build);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
                 "[Text Finder] Finished looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);
-        TestUtils.assertConsoleContainsMatch(ECHO_UNIQUE_TEXT, rule, build, true);
     }
 }

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherAgentTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherAgentTest.java
@@ -14,8 +14,6 @@ import java.io.File;
 
 public class TextFinderPublisherAgentTest {
 
-    private static final String UNIQUE_TEXT = "foobar";
-
     @Rule public JenkinsRule rule = new JenkinsRule();
 
     @Test
@@ -33,10 +31,17 @@ public class TextFinderPublisherAgentTest {
                         true));
         WorkflowRun build = rule.buildAndAssertStatus(Result.FAILURE, project);
         rule.assertLogContains(
-                "[Text Finder] Looking for pattern " + "'" + UNIQUE_TEXT + "'" + " in the files at",
+                "[Text Finder] Looking for pattern "
+                        + "'"
+                        + TestUtils.UNIQUE_TEXT
+                        + "'"
+                        + " in the files at",
                 build);
         TestUtils.assertFileContainsMatch(
-                new File(TestUtils.getWorkspace(build), "out.txt"), UNIQUE_TEXT, rule, build);
+                new File(TestUtils.getWorkspace(build), "out.txt"),
+                TestUtils.UNIQUE_TEXT,
+                rule,
+                build);
     }
 
     @Test
@@ -48,7 +53,7 @@ public class TextFinderPublisherAgentTest {
                         String.format(
                                 "node('%s') {\n"
                                         + "  testEcho '"
-                                        + UNIQUE_TEXT
+                                        + TestUtils.UNIQUE_TEXT
                                         + "'\n"
                                         + "  findText regexp: 'foobar', alsoCheckConsoleOutput:"
                                         + " true\n"
@@ -56,11 +61,11 @@ public class TextFinderPublisherAgentTest {
                                 agent.getNodeName()),
                         true));
         WorkflowRun build = rule.buildAndAssertStatus(Result.FAILURE, project);
-        rule.assertLogContains(TestUtils.PREFIX + UNIQUE_TEXT, build);
+        rule.assertLogContains(TestUtils.PREFIX + TestUtils.UNIQUE_TEXT, build);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
                 "[Text Finder] Finished looking for pattern '"
-                        + UNIQUE_TEXT
+                        + TestUtils.UNIQUE_TEXT
                         + "' in the console output",
                 build);
     }

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleJobDslTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleJobDslTest.java
@@ -1,0 +1,365 @@
+package hudson.plugins.textfinder;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+
+import javaposse.jobdsl.plugin.ExecuteDslScripts;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.File;
+
+public class TextFinderPublisherFreestyleJobDslTest {
+
+    @Rule public JenkinsRule rule = new JenkinsRule();
+
+    @Test
+    public void successIfFoundInFile() throws Exception {
+        FreeStyleProject project =
+                createProjectFromDsl(
+                        "  steps {\n"
+                                + "    testWriteFileBuilder {"
+                                + "      file '"
+                                + TestUtils.FILE_SET
+                                + "'\n"
+                                + "      text '"
+                                + TestUtils.UNIQUE_TEXT
+                                + "'\n"
+                                + "    }\n"
+                                + "  }\n"
+                                + "  publishers {\n"
+                                + "    findText {"
+                                + "      regexp '"
+                                + TestUtils.UNIQUE_TEXT
+                                + "'\n"
+                                + "      fileSet '"
+                                + TestUtils.FILE_SET
+                                + "'\n"
+                                + "      succeedIfFound true\n"
+                                + "    }\n"
+                                + "  }\n");
+        FreeStyleBuild build = rule.buildAndAssertSuccess(project);
+        rule.assertLogContains(
+                "[Text Finder] Looking for pattern '"
+                        + TestUtils.UNIQUE_TEXT
+                        + "' in the files at "
+                        + "'"
+                        + TestUtils.FILE_SET
+                        + "'",
+                build);
+        TestUtils.assertFileContainsMatch(
+                new File(build.getWorkspace().getRemote(), TestUtils.FILE_SET),
+                TestUtils.UNIQUE_TEXT,
+                rule,
+                build);
+    }
+
+    @Test
+    public void failureIfFoundInFile() throws Exception {
+        FreeStyleProject project =
+                createProjectFromDsl(
+                        "  steps {\n"
+                                + "    testWriteFileBuilder {"
+                                + "      file '"
+                                + TestUtils.FILE_SET
+                                + "'\n"
+                                + "      text '"
+                                + TestUtils.UNIQUE_TEXT
+                                + "'\n"
+                                + "    }\n"
+                                + "  }\n"
+                                + "  publishers {\n"
+                                + "    findText {"
+                                + "      regexp '"
+                                + TestUtils.UNIQUE_TEXT
+                                + "'\n"
+                                + "      fileSet '"
+                                + TestUtils.FILE_SET
+                                + "'\n"
+                                + "    }\n"
+                                + "  }\n");
+        FreeStyleBuild build = rule.buildAndAssertStatus(Result.FAILURE, project);
+        rule.assertLogContains(
+                "[Text Finder] Looking for pattern '"
+                        + TestUtils.UNIQUE_TEXT
+                        + "' in the files at "
+                        + "'"
+                        + TestUtils.FILE_SET
+                        + "'",
+                build);
+        TestUtils.assertFileContainsMatch(
+                new File(build.getWorkspace().getRemote(), TestUtils.FILE_SET),
+                TestUtils.UNIQUE_TEXT,
+                rule,
+                build);
+    }
+
+    @Test
+    public void unstableIfFoundInFile() throws Exception {
+        FreeStyleProject project =
+                createProjectFromDsl(
+                        "  steps {\n"
+                                + "    testWriteFileBuilder {"
+                                + "      file '"
+                                + TestUtils.FILE_SET
+                                + "'\n"
+                                + "      text '"
+                                + TestUtils.UNIQUE_TEXT
+                                + "'\n"
+                                + "    }\n"
+                                + "  }\n"
+                                + "  publishers {\n"
+                                + "    findText {"
+                                + "      regexp '"
+                                + TestUtils.UNIQUE_TEXT
+                                + "'\n"
+                                + "      fileSet '"
+                                + TestUtils.FILE_SET
+                                + "'\n"
+                                + "      unstableIfFound true\n"
+                                + "    }\n"
+                                + "  }\n");
+        FreeStyleBuild build = rule.buildAndAssertStatus(Result.UNSTABLE, project);
+        rule.assertLogContains(
+                "[Text Finder] Looking for pattern '"
+                        + TestUtils.UNIQUE_TEXT
+                        + "' in the files at "
+                        + "'"
+                        + TestUtils.FILE_SET
+                        + "'",
+                build);
+        TestUtils.assertFileContainsMatch(
+                new File(build.getWorkspace().getRemote(), TestUtils.FILE_SET),
+                TestUtils.UNIQUE_TEXT,
+                rule,
+                build);
+    }
+
+    @Test
+    public void notBuiltIfFoundInFile() throws Exception {
+        FreeStyleProject project =
+                createProjectFromDsl(
+                        "  steps {\n"
+                                + "    testWriteFileBuilder {"
+                                + "      file '"
+                                + TestUtils.FILE_SET
+                                + "'\n"
+                                + "      text '"
+                                + TestUtils.UNIQUE_TEXT
+                                + "'\n"
+                                + "    }\n"
+                                + "  }\n"
+                                + "  publishers {\n"
+                                + "    findText {"
+                                + "      regexp '"
+                                + TestUtils.UNIQUE_TEXT
+                                + "'\n"
+                                + "      fileSet '"
+                                + TestUtils.FILE_SET
+                                + "'\n"
+                                + "      notBuiltIfFound true\n"
+                                + "    }\n"
+                                + "  }\n");
+        FreeStyleBuild build = rule.buildAndAssertStatus(Result.NOT_BUILT, project);
+        rule.assertLogContains(
+                "[Text Finder] Looking for pattern '"
+                        + TestUtils.UNIQUE_TEXT
+                        + "' in the files at "
+                        + "'"
+                        + TestUtils.FILE_SET
+                        + "'",
+                build);
+        TestUtils.assertFileContainsMatch(
+                new File(build.getWorkspace().getRemote(), TestUtils.FILE_SET),
+                TestUtils.UNIQUE_TEXT,
+                rule,
+                build);
+    }
+
+    @Test
+    public void notFoundInFile() throws Exception {
+        FreeStyleProject project =
+                createProjectFromDsl(
+                        "  steps {\n"
+                                + "    testWriteFileBuilder {"
+                                + "      file '"
+                                + TestUtils.FILE_SET
+                                + "'\n"
+                                + "      text 'foobaz'\n"
+                                + "    }\n"
+                                + "  }\n"
+                                + "  publishers {\n"
+                                + "    findText {"
+                                + "      regexp '"
+                                + TestUtils.UNIQUE_TEXT
+                                + "'\n"
+                                + "      fileSet '"
+                                + TestUtils.FILE_SET
+                                + "'\n"
+                                + "    }\n"
+                                + "  }\n");
+        FreeStyleBuild build = rule.buildAndAssertSuccess(project);
+        rule.assertLogContains(
+                "[Text Finder] Looking for pattern '"
+                        + TestUtils.UNIQUE_TEXT
+                        + "' in the files at "
+                        + "'"
+                        + TestUtils.FILE_SET
+                        + "'",
+                build);
+    }
+
+    @Test
+    public void successIfFoundInConsole() throws Exception {
+        FreeStyleProject project =
+                createProjectFromDsl(
+                        "  steps {\n"
+                                + "    testEchoBuilder {"
+                                + "      message '"
+                                + TestUtils.UNIQUE_TEXT
+                                + "'\n"
+                                + "    }\n"
+                                + "  }\n"
+                                + "  publishers {\n"
+                                + "    findText {"
+                                + "      regexp '"
+                                + TestUtils.UNIQUE_TEXT
+                                + "'\n"
+                                + "      succeedIfFound true\n"
+                                + "      alsoCheckConsoleOutput true\n"
+                                + "    }\n"
+                                + "  }\n");
+        FreeStyleBuild build = rule.buildAndAssertSuccess(project);
+        rule.assertLogContains(TestUtils.PREFIX + TestUtils.UNIQUE_TEXT, build);
+        rule.assertLogContains("[Text Finder] Scanning console output...", build);
+        rule.assertLogContains(
+                "[Text Finder] Finished looking for pattern '"
+                        + TestUtils.UNIQUE_TEXT
+                        + "' in the console output",
+                build);
+    }
+
+    @Test
+    public void failureIfFoundInConsole() throws Exception {
+        FreeStyleProject project =
+                createProjectFromDsl(
+                        "  steps {\n"
+                                + "    testEchoBuilder {"
+                                + "      message '"
+                                + TestUtils.UNIQUE_TEXT
+                                + "'\n"
+                                + "    }\n"
+                                + "  }\n"
+                                + "  publishers {\n"
+                                + "    findText {"
+                                + "      regexp '"
+                                + TestUtils.UNIQUE_TEXT
+                                + "'\n"
+                                + "      alsoCheckConsoleOutput true\n"
+                                + "    }\n"
+                                + "  }\n");
+        FreeStyleBuild build = rule.buildAndAssertStatus(Result.FAILURE, project);
+        rule.assertLogContains(TestUtils.PREFIX + TestUtils.UNIQUE_TEXT, build);
+        rule.assertLogContains("[Text Finder] Scanning console output...", build);
+        rule.assertLogContains(
+                "[Text Finder] Finished looking for pattern '"
+                        + TestUtils.UNIQUE_TEXT
+                        + "' in the console output",
+                build);
+    }
+
+    @Test
+    public void unstableIfFoundInConsole() throws Exception {
+        FreeStyleProject project =
+                createProjectFromDsl(
+                        "  steps {\n"
+                                + "    testEchoBuilder {"
+                                + "      message '"
+                                + TestUtils.UNIQUE_TEXT
+                                + "'\n"
+                                + "    }\n"
+                                + "  }\n"
+                                + "  publishers {\n"
+                                + "    findText {"
+                                + "      regexp '"
+                                + TestUtils.UNIQUE_TEXT
+                                + "'\n"
+                                + "      unstableIfFound true\n"
+                                + "      alsoCheckConsoleOutput true\n"
+                                + "    }\n"
+                                + "  }\n");
+        FreeStyleBuild build = rule.buildAndAssertStatus(Result.UNSTABLE, project);
+        rule.assertLogContains(TestUtils.PREFIX + TestUtils.UNIQUE_TEXT, build);
+        rule.assertLogContains("[Text Finder] Scanning console output...", build);
+        rule.assertLogContains(
+                "[Text Finder] Finished looking for pattern '"
+                        + TestUtils.UNIQUE_TEXT
+                        + "' in the console output",
+                build);
+    }
+
+    @Test
+    public void notBuiltIfFoundInConsole() throws Exception {
+        FreeStyleProject project =
+                createProjectFromDsl(
+                        "  steps {\n"
+                                + "    testEchoBuilder {"
+                                + "      message '"
+                                + TestUtils.UNIQUE_TEXT
+                                + "'\n"
+                                + "    }\n"
+                                + "  }\n"
+                                + "  publishers {\n"
+                                + "    findText {"
+                                + "      regexp '"
+                                + TestUtils.UNIQUE_TEXT
+                                + "'\n"
+                                + "      notBuiltIfFound true\n"
+                                + "      alsoCheckConsoleOutput true\n"
+                                + "    }\n"
+                                + "  }\n");
+        FreeStyleBuild build = rule.buildAndAssertStatus(Result.NOT_BUILT, project);
+        rule.assertLogContains(TestUtils.PREFIX + TestUtils.UNIQUE_TEXT, build);
+        rule.assertLogContains("[Text Finder] Scanning console output...", build);
+        rule.assertLogContains(
+                "[Text Finder] Finished looking for pattern '"
+                        + TestUtils.UNIQUE_TEXT
+                        + "' in the console output",
+                build);
+    }
+
+    @Test
+    public void notFoundInConsole() throws Exception {
+        FreeStyleProject project =
+                createProjectFromDsl(
+                        "  publishers {\n"
+                                + "    findText {"
+                                + "      regexp '"
+                                + TestUtils.UNIQUE_TEXT
+                                + "'\n"
+                                + "      alsoCheckConsoleOutput true\n"
+                                + "    }\n"
+                                + "  }\n");
+        FreeStyleBuild build = rule.buildAndAssertSuccess(project);
+        rule.assertLogContains("[Text Finder] Scanning console output...", build);
+        rule.assertLogContains(
+                "[Text Finder] Finished looking for pattern '"
+                        + TestUtils.UNIQUE_TEXT
+                        + "' in the console output",
+                build);
+    }
+
+    private FreeStyleProject createProjectFromDsl(String dsl) throws Exception {
+        FreeStyleProject seed = rule.createFreeStyleProject();
+        ExecuteDslScripts executeDslScripts = new ExecuteDslScripts();
+        String generatedJobName = "test" + rule.jenkins.getItems().size();
+        executeDslScripts.setScriptText("job('" + generatedJobName + "') {\n" + dsl + "}\n");
+        executeDslScripts.setUseScriptText(true);
+        seed.getBuildersList().add(executeDslScripts);
+        rule.buildAndAssertSuccess(seed);
+        return rule.jenkins.getItemByFullName(generatedJobName, FreeStyleProject.class);
+    }
+}

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
@@ -14,7 +14,6 @@ import java.io.File;
 public class TextFinderPublisherPipelineTest {
 
     private static final String UNIQUE_TEXT = "foobar";
-    private static final String ECHO_UNIQUE_TEXT = "echo " + UNIQUE_TEXT;
     private static final String fileSet = "out.txt";
 
     @Rule public JenkinsRule rule = new JenkinsRule();
@@ -47,7 +46,7 @@ public class TextFinderPublisherPipelineTest {
                         + "'",
                 build);
         TestUtils.assertFileContainsMatch(
-                new File(TestUtils.getWorkspace(build), fileSet), UNIQUE_TEXT, rule, build, false);
+                new File(TestUtils.getWorkspace(build), fileSet), UNIQUE_TEXT, rule, build);
     }
 
     @Test
@@ -78,7 +77,7 @@ public class TextFinderPublisherPipelineTest {
                         + "'",
                 build);
         TestUtils.assertFileContainsMatch(
-                new File(TestUtils.getWorkspace(build), fileSet), UNIQUE_TEXT, rule, build, false);
+                new File(TestUtils.getWorkspace(build), fileSet), UNIQUE_TEXT, rule, build);
     }
 
     @Test
@@ -109,7 +108,7 @@ public class TextFinderPublisherPipelineTest {
                         + "'",
                 build);
         TestUtils.assertFileContainsMatch(
-                new File(TestUtils.getWorkspace(build), fileSet), UNIQUE_TEXT, rule, build, false);
+                new File(TestUtils.getWorkspace(build), fileSet), UNIQUE_TEXT, rule, build);
     }
 
     @Test
@@ -140,7 +139,7 @@ public class TextFinderPublisherPipelineTest {
                         + "'",
                 build);
         TestUtils.assertFileContainsMatch(
-                new File(TestUtils.getWorkspace(build), fileSet), UNIQUE_TEXT, rule, build, false);
+                new File(TestUtils.getWorkspace(build), fileSet), UNIQUE_TEXT, rule, build);
     }
 
     @Test
@@ -175,25 +174,23 @@ public class TextFinderPublisherPipelineTest {
         WorkflowJob project = rule.createProject(WorkflowJob.class);
         project.setDefinition(
                 new CpsFlowDefinition(
-                        "node {\n"
-                                + "  isUnix() ? sh('"
-                                + ECHO_UNIQUE_TEXT
-                                + "') : bat(\"prompt \\$G\\r\\n"
-                                + ECHO_UNIQUE_TEXT
-                                + "\")\n"
+                        "  testEcho '"
+                                + UNIQUE_TEXT
+                                + "'\n"
+                                + "node {\n"
                                 + "  findText regexp: '"
                                 + UNIQUE_TEXT
                                 + "', succeedIfFound: true, alsoCheckConsoleOutput: true\n"
                                 + "}\n",
                         true));
         WorkflowRun build = rule.buildAndAssertSuccess(project);
+        rule.assertLogContains(TestUtils.PREFIX + UNIQUE_TEXT, build);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
                 "[Text Finder] Finished looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);
-        TestUtils.assertConsoleContainsMatch(ECHO_UNIQUE_TEXT, rule, build, true);
     }
 
     @Test
@@ -201,25 +198,23 @@ public class TextFinderPublisherPipelineTest {
         WorkflowJob project = rule.createProject(WorkflowJob.class);
         project.setDefinition(
                 new CpsFlowDefinition(
-                        "node {\n"
-                                + "  isUnix() ? sh('"
-                                + ECHO_UNIQUE_TEXT
-                                + "') : bat(\"prompt \\$G\\r\\n"
-                                + ECHO_UNIQUE_TEXT
-                                + "\")\n"
+                        "  testEcho '"
+                                + UNIQUE_TEXT
+                                + "'\n"
+                                + "node {\n"
                                 + "  findText regexp: '"
                                 + UNIQUE_TEXT
                                 + "', alsoCheckConsoleOutput: true\n"
                                 + "}\n",
                         true));
         WorkflowRun build = rule.buildAndAssertStatus(Result.FAILURE, project);
+        rule.assertLogContains(TestUtils.PREFIX + UNIQUE_TEXT, build);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
                 "[Text Finder] Finished looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);
-        TestUtils.assertConsoleContainsMatch(ECHO_UNIQUE_TEXT, rule, build, true);
     }
 
     @Test
@@ -227,25 +222,23 @@ public class TextFinderPublisherPipelineTest {
         WorkflowJob project = rule.createProject(WorkflowJob.class);
         project.setDefinition(
                 new CpsFlowDefinition(
-                        "node {\n"
-                                + "  isUnix() ? sh('"
-                                + ECHO_UNIQUE_TEXT
-                                + "') : bat(\"prompt \\$G\\r\\n"
-                                + ECHO_UNIQUE_TEXT
-                                + "\")\n"
+                        "  testEcho '"
+                                + UNIQUE_TEXT
+                                + "'\n"
+                                + "node {\n"
                                 + "  findText regexp: '"
                                 + UNIQUE_TEXT
                                 + "', unstableIfFound: true, alsoCheckConsoleOutput: true\n"
                                 + "}\n",
                         true));
         WorkflowRun build = rule.buildAndAssertStatus(Result.UNSTABLE, project);
+        rule.assertLogContains(TestUtils.PREFIX + UNIQUE_TEXT, build);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
                 "[Text Finder] Finished looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);
-        TestUtils.assertConsoleContainsMatch(ECHO_UNIQUE_TEXT, rule, build, true);
     }
 
     @Test
@@ -253,25 +246,23 @@ public class TextFinderPublisherPipelineTest {
         WorkflowJob project = rule.createProject(WorkflowJob.class);
         project.setDefinition(
                 new CpsFlowDefinition(
-                        "node {\n"
-                                + "  isUnix() ? sh('"
-                                + ECHO_UNIQUE_TEXT
-                                + "') : bat(\"prompt \\$G\\r\\n"
-                                + ECHO_UNIQUE_TEXT
-                                + "\")\n"
+                        "  testEcho '"
+                                + UNIQUE_TEXT
+                                + "'\n"
+                                + "node {\n"
                                 + "  findText regexp: '"
                                 + UNIQUE_TEXT
                                 + "', notBuiltIfFound: true, alsoCheckConsoleOutput: true\n"
                                 + "}\n",
                         true));
         WorkflowRun build = rule.buildAndAssertStatus(Result.NOT_BUILT, project);
+        rule.assertLogContains(TestUtils.PREFIX + UNIQUE_TEXT, build);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
                 "[Text Finder] Finished looking for pattern '"
                         + UNIQUE_TEXT
                         + "' in the console output",
                 build);
-        TestUtils.assertConsoleContainsMatch(ECHO_UNIQUE_TEXT, rule, build, true);
     }
 
     @Test

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherPipelineTest.java
@@ -13,9 +13,6 @@ import java.io.File;
 
 public class TextFinderPublisherPipelineTest {
 
-    private static final String UNIQUE_TEXT = "foobar";
-    private static final String fileSet = "out.txt";
-
     @Rule public JenkinsRule rule = new JenkinsRule();
 
     @Test
@@ -25,28 +22,31 @@ public class TextFinderPublisherPipelineTest {
                 new CpsFlowDefinition(
                         "node {\n"
                                 + "  writeFile file: '"
-                                + fileSet
+                                + TestUtils.FILE_SET
                                 + "', text: '"
-                                + UNIQUE_TEXT
+                                + TestUtils.UNIQUE_TEXT
                                 + "'\n"
                                 + "  findText regexp: '"
-                                + UNIQUE_TEXT
+                                + TestUtils.UNIQUE_TEXT
                                 + "', fileSet: '"
-                                + fileSet
+                                + TestUtils.FILE_SET
                                 + "', succeedIfFound: true\n"
                                 + "}\n",
                         true));
         WorkflowRun build = rule.buildAndAssertSuccess(project);
         rule.assertLogContains(
                 "[Text Finder] Looking for pattern '"
-                        + UNIQUE_TEXT
+                        + TestUtils.UNIQUE_TEXT
                         + "' in the files at "
                         + "'"
-                        + fileSet
+                        + TestUtils.FILE_SET
                         + "'",
                 build);
         TestUtils.assertFileContainsMatch(
-                new File(TestUtils.getWorkspace(build), fileSet), UNIQUE_TEXT, rule, build);
+                new File(TestUtils.getWorkspace(build), TestUtils.FILE_SET),
+                TestUtils.UNIQUE_TEXT,
+                rule,
+                build);
     }
 
     @Test
@@ -56,28 +56,31 @@ public class TextFinderPublisherPipelineTest {
                 new CpsFlowDefinition(
                         "node {\n"
                                 + "  writeFile file: '"
-                                + fileSet
+                                + TestUtils.FILE_SET
                                 + "', text: '"
-                                + UNIQUE_TEXT
+                                + TestUtils.UNIQUE_TEXT
                                 + "'\n"
                                 + "  findText regexp: '"
-                                + UNIQUE_TEXT
+                                + TestUtils.UNIQUE_TEXT
                                 + "', fileSet: '"
-                                + fileSet
+                                + TestUtils.FILE_SET
                                 + "'\n"
                                 + "}\n",
                         true));
         WorkflowRun build = rule.buildAndAssertStatus(Result.FAILURE, project);
         rule.assertLogContains(
                 "[Text Finder] Looking for pattern '"
-                        + UNIQUE_TEXT
+                        + TestUtils.UNIQUE_TEXT
                         + "' in the files at "
                         + "'"
-                        + fileSet
+                        + TestUtils.FILE_SET
                         + "'",
                 build);
         TestUtils.assertFileContainsMatch(
-                new File(TestUtils.getWorkspace(build), fileSet), UNIQUE_TEXT, rule, build);
+                new File(TestUtils.getWorkspace(build), TestUtils.FILE_SET),
+                TestUtils.UNIQUE_TEXT,
+                rule,
+                build);
     }
 
     @Test
@@ -87,28 +90,31 @@ public class TextFinderPublisherPipelineTest {
                 new CpsFlowDefinition(
                         "node {\n"
                                 + "  writeFile file: '"
-                                + fileSet
+                                + TestUtils.FILE_SET
                                 + "', text: '"
-                                + UNIQUE_TEXT
+                                + TestUtils.UNIQUE_TEXT
                                 + "'\n"
                                 + "  findText regexp: '"
-                                + UNIQUE_TEXT
+                                + TestUtils.UNIQUE_TEXT
                                 + "', fileSet: '"
-                                + fileSet
+                                + TestUtils.FILE_SET
                                 + "', unstableIfFound: true\n"
                                 + "}\n",
                         true));
         WorkflowRun build = rule.buildAndAssertStatus(Result.UNSTABLE, project);
         rule.assertLogContains(
                 "[Text Finder] Looking for pattern '"
-                        + UNIQUE_TEXT
+                        + TestUtils.UNIQUE_TEXT
                         + "' in the files at "
                         + "'"
-                        + fileSet
+                        + TestUtils.FILE_SET
                         + "'",
                 build);
         TestUtils.assertFileContainsMatch(
-                new File(TestUtils.getWorkspace(build), fileSet), UNIQUE_TEXT, rule, build);
+                new File(TestUtils.getWorkspace(build), TestUtils.FILE_SET),
+                TestUtils.UNIQUE_TEXT,
+                rule,
+                build);
     }
 
     @Test
@@ -118,28 +124,31 @@ public class TextFinderPublisherPipelineTest {
                 new CpsFlowDefinition(
                         "node {\n"
                                 + "  writeFile file: '"
-                                + fileSet
+                                + TestUtils.FILE_SET
                                 + "', text: '"
-                                + UNIQUE_TEXT
+                                + TestUtils.UNIQUE_TEXT
                                 + "'\n"
                                 + "  findText regexp: '"
-                                + UNIQUE_TEXT
+                                + TestUtils.UNIQUE_TEXT
                                 + "', fileSet: '"
-                                + fileSet
+                                + TestUtils.FILE_SET
                                 + "', notBuiltIfFound: true\n"
                                 + "}\n",
                         true));
         WorkflowRun build = rule.buildAndAssertStatus(Result.NOT_BUILT, project);
         rule.assertLogContains(
                 "[Text Finder] Looking for pattern '"
-                        + UNIQUE_TEXT
+                        + TestUtils.UNIQUE_TEXT
                         + "' in the files at "
                         + "'"
-                        + fileSet
+                        + TestUtils.FILE_SET
                         + "'",
                 build);
         TestUtils.assertFileContainsMatch(
-                new File(TestUtils.getWorkspace(build), fileSet), UNIQUE_TEXT, rule, build);
+                new File(TestUtils.getWorkspace(build), TestUtils.FILE_SET),
+                TestUtils.UNIQUE_TEXT,
+                rule,
+                build);
     }
 
     @Test
@@ -149,22 +158,22 @@ public class TextFinderPublisherPipelineTest {
                 new CpsFlowDefinition(
                         "node {\n"
                                 + "  writeFile file: '"
-                                + fileSet
+                                + TestUtils.FILE_SET
                                 + "', text: 'foobaz'\n"
                                 + "  findText regexp: '"
-                                + UNIQUE_TEXT
+                                + TestUtils.UNIQUE_TEXT
                                 + "', fileSet: '"
-                                + fileSet
+                                + TestUtils.FILE_SET
                                 + "'\n"
                                 + "}\n",
                         true));
         WorkflowRun build = rule.buildAndAssertSuccess(project);
         rule.assertLogContains(
                 "[Text Finder] Looking for pattern '"
-                        + UNIQUE_TEXT
+                        + TestUtils.UNIQUE_TEXT
                         + "' in the files at "
                         + "'"
-                        + fileSet
+                        + TestUtils.FILE_SET
                         + "'",
                 build);
     }
@@ -175,20 +184,20 @@ public class TextFinderPublisherPipelineTest {
         project.setDefinition(
                 new CpsFlowDefinition(
                         "  testEcho '"
-                                + UNIQUE_TEXT
+                                + TestUtils.UNIQUE_TEXT
                                 + "'\n"
                                 + "node {\n"
                                 + "  findText regexp: '"
-                                + UNIQUE_TEXT
+                                + TestUtils.UNIQUE_TEXT
                                 + "', succeedIfFound: true, alsoCheckConsoleOutput: true\n"
                                 + "}\n",
                         true));
         WorkflowRun build = rule.buildAndAssertSuccess(project);
-        rule.assertLogContains(TestUtils.PREFIX + UNIQUE_TEXT, build);
+        rule.assertLogContains(TestUtils.PREFIX + TestUtils.UNIQUE_TEXT, build);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
                 "[Text Finder] Finished looking for pattern '"
-                        + UNIQUE_TEXT
+                        + TestUtils.UNIQUE_TEXT
                         + "' in the console output",
                 build);
     }
@@ -199,20 +208,20 @@ public class TextFinderPublisherPipelineTest {
         project.setDefinition(
                 new CpsFlowDefinition(
                         "  testEcho '"
-                                + UNIQUE_TEXT
+                                + TestUtils.UNIQUE_TEXT
                                 + "'\n"
                                 + "node {\n"
                                 + "  findText regexp: '"
-                                + UNIQUE_TEXT
+                                + TestUtils.UNIQUE_TEXT
                                 + "', alsoCheckConsoleOutput: true\n"
                                 + "}\n",
                         true));
         WorkflowRun build = rule.buildAndAssertStatus(Result.FAILURE, project);
-        rule.assertLogContains(TestUtils.PREFIX + UNIQUE_TEXT, build);
+        rule.assertLogContains(TestUtils.PREFIX + TestUtils.UNIQUE_TEXT, build);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
                 "[Text Finder] Finished looking for pattern '"
-                        + UNIQUE_TEXT
+                        + TestUtils.UNIQUE_TEXT
                         + "' in the console output",
                 build);
     }
@@ -223,20 +232,20 @@ public class TextFinderPublisherPipelineTest {
         project.setDefinition(
                 new CpsFlowDefinition(
                         "  testEcho '"
-                                + UNIQUE_TEXT
+                                + TestUtils.UNIQUE_TEXT
                                 + "'\n"
                                 + "node {\n"
                                 + "  findText regexp: '"
-                                + UNIQUE_TEXT
+                                + TestUtils.UNIQUE_TEXT
                                 + "', unstableIfFound: true, alsoCheckConsoleOutput: true\n"
                                 + "}\n",
                         true));
         WorkflowRun build = rule.buildAndAssertStatus(Result.UNSTABLE, project);
-        rule.assertLogContains(TestUtils.PREFIX + UNIQUE_TEXT, build);
+        rule.assertLogContains(TestUtils.PREFIX + TestUtils.UNIQUE_TEXT, build);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
                 "[Text Finder] Finished looking for pattern '"
-                        + UNIQUE_TEXT
+                        + TestUtils.UNIQUE_TEXT
                         + "' in the console output",
                 build);
     }
@@ -247,20 +256,20 @@ public class TextFinderPublisherPipelineTest {
         project.setDefinition(
                 new CpsFlowDefinition(
                         "  testEcho '"
-                                + UNIQUE_TEXT
+                                + TestUtils.UNIQUE_TEXT
                                 + "'\n"
                                 + "node {\n"
                                 + "  findText regexp: '"
-                                + UNIQUE_TEXT
+                                + TestUtils.UNIQUE_TEXT
                                 + "', notBuiltIfFound: true, alsoCheckConsoleOutput: true\n"
                                 + "}\n",
                         true));
         WorkflowRun build = rule.buildAndAssertStatus(Result.NOT_BUILT, project);
-        rule.assertLogContains(TestUtils.PREFIX + UNIQUE_TEXT, build);
+        rule.assertLogContains(TestUtils.PREFIX + TestUtils.UNIQUE_TEXT, build);
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
                 "[Text Finder] Finished looking for pattern '"
-                        + UNIQUE_TEXT
+                        + TestUtils.UNIQUE_TEXT
                         + "' in the console output",
                 build);
     }
@@ -272,7 +281,7 @@ public class TextFinderPublisherPipelineTest {
                 new CpsFlowDefinition(
                         "node {\n"
                                 + "  findText regexp: '"
-                                + UNIQUE_TEXT
+                                + TestUtils.UNIQUE_TEXT
                                 + "', alsoCheckConsoleOutput: true\n"
                                 + "}\n",
                         true));
@@ -280,7 +289,7 @@ public class TextFinderPublisherPipelineTest {
         rule.assertLogContains("[Text Finder] Scanning console output...", build);
         rule.assertLogContains(
                 "[Text Finder] Finished looking for pattern '"
-                        + UNIQUE_TEXT
+                        + TestUtils.UNIQUE_TEXT
                         + "' in the console output",
                 build);
     }

--- a/src/test/java/hudson/plugins/textfinder/test/TestEchoBuilder.java
+++ b/src/test/java/hudson/plugins/textfinder/test/TestEchoBuilder.java
@@ -1,0 +1,26 @@
+package hudson.plugins.textfinder.test;
+
+import hudson.Launcher;
+import hudson.model.*;
+import hudson.plugins.textfinder.TestUtils;
+import hudson.tasks.Builder;
+
+import org.jvnet.hudson.test.TestBuilder;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/** A test {@link Builder} that merely prints the message given to it with a prefix. */
+public class TestEchoBuilder extends TestBuilder {
+
+    private final String message;
+
+    @DataBoundConstructor
+    public TestEchoBuilder(String message) {
+        this.message = TestUtils.PREFIX + message;
+    }
+
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
+        listener.getLogger().println(message);
+        return true;
+    }
+}

--- a/src/test/java/hudson/plugins/textfinder/test/TestEchoStep.java
+++ b/src/test/java/hudson/plugins/textfinder/test/TestEchoStep.java
@@ -1,0 +1,26 @@
+package hudson.plugins.textfinder.test;
+
+import hudson.Extension;
+import hudson.plugins.textfinder.TestUtils;
+
+import org.jenkinsci.plugins.workflow.steps.EchoStep;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/** A test {@link Step} that merely prints the message given to it with a prefix. */
+public class TestEchoStep extends EchoStep {
+
+    @DataBoundConstructor
+    public TestEchoStep(String message) {
+        super(TestUtils.PREFIX + message);
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends EchoStep.DescriptorImpl {
+
+        @Override
+        public String getFunctionName() {
+            return "testEcho";
+        }
+    }
+}

--- a/src/test/java/hudson/plugins/textfinder/test/TestWriteFileBuilder.java
+++ b/src/test/java/hudson/plugins/textfinder/test/TestWriteFileBuilder.java
@@ -3,8 +3,9 @@ package hudson.plugins.textfinder.test;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.*;
-import hudson.plugins.textfinder.TestUtils;
+import hudson.model.AbstractProject;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 
@@ -13,16 +14,19 @@ import jenkins.tasks.SimpleBuildStep;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.io.IOException;
+
 import javax.annotation.Nonnull;
 
-/** A test {@link Builder} that merely prints the message given to it with a prefix. */
-public class TestEchoBuilder extends Builder implements SimpleBuildStep {
+public class TestWriteFileBuilder extends Builder implements SimpleBuildStep {
 
-    private final String message;
+    private final String file;
+    private final String text;
 
     @DataBoundConstructor
-    public TestEchoBuilder(String message) {
-        this.message = TestUtils.PREFIX + message;
+    public TestWriteFileBuilder(String file, String text) {
+        this.file = file;
+        this.text = text;
     }
 
     @Override
@@ -30,11 +34,13 @@ public class TestEchoBuilder extends Builder implements SimpleBuildStep {
             @Nonnull Run<?, ?> run,
             @Nonnull FilePath workspace,
             @Nonnull Launcher launcher,
-            @Nonnull TaskListener listener) {
-        listener.getLogger().println(message);
+            @Nonnull TaskListener listener)
+            throws InterruptedException, IOException {
+        FilePath filePath = workspace.child(file);
+        filePath.write(text, null);
     }
 
-    @Symbol("testEchoBuilder")
+    @Symbol("testWriteFileBuilder")
     @Extension
     public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
 


### PR DESCRIPTION
The test suite for this plugin used `sh`/`bat` steps for printing content. This made the tests difficult to reason about and debug, especially when developing on a Unix platform and trying to debug the tests on Windows. This change simplifies the test suite by adding a custom `Builder` and `Step` for printing out the content to be searched. This makes the test suite easier to reason about, as the same code gets run regardless of platform.