### PR TITLE
[JENKINS-62734] Text Finder 1.13 no longer supports setting the build result when a match is not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,8 @@
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=jenkinsci/text-finder-plugin)](https://dependabot.com)
 
 This plugin lets you search for some text using regular expressions in a
-set of files or the console log. Once a match is found, you can
-downgrade the build result to `UNSTABLE`, `FAILURE`, `NOT_BUILT`, or
-`ABORTED`. See the Jenkins
-[`Result`](https://javadoc.jenkins-ci.org/hudson/model/Result.html)
-class for more information.
+set of files or the console log. Based on the outcome, you can downgrade
+the build result to `UNSTABLE`, `FAILURE`, `NOT_BUILT`, or `ABORTED`.
 
 For example, you can search for the string `failure` in a set of log
 files. If a match is found, you can downgrade the build result from
@@ -57,8 +54,15 @@ findText(textFinders: [textFinder([...], buildResult: 'UNSTABLE')])
 
 If a match is found, the build result will be set to this value. Note
 that the build result can only get worse, so you cannot change the
-result to `SUCCESS` if the current result is `UNSTABLE` or worse. Use
-`SUCCESS` to keep the build result from being set when a match is found.
+result to `SUCCESS` if the current result is `UNSTABLE` or worse.
+
+Whether or not a build is downgraded depends on its change condition. The
+default change condition is `MATCH_FOUND`, which downgrades the build result if
+a match is found. To downgrade the build result if a match is _not_ found, set
+the change condition to `MATCH_NOT_FOUND`:
+
+```
+findText(textFinders: [textFinder([...], changeCondition: 'MATCH_NOT_FOUND', buildResult: 'UNSTABLE')])
 
 To search for multiple regular expressions, use the following syntax:
 
@@ -85,6 +89,7 @@ job('example') {
         textFinder {
           regexp '<regular expression>'
           fileSet '<file set>'
+          changeCondition '<MATCH_FOUND or MATCH_NOT_FOUND>'
           alsoCheckConsoleOutput true
           buildResult 'UNSTABLE'
         }

--- a/src/main/java/hudson/plugins/textfinder/TextFinder.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinder.java
@@ -29,6 +29,7 @@ public class TextFinder extends AbstractDescribableImpl<TextFinder> implements S
     @Nonnull private /* final */ String regexp;
     @CheckForNull private String fileSet;
     @Nonnull private String buildResult = Result.FAILURE.toString();
+    private TextFinderChangeCondition changeCondition = TextFinderChangeCondition.MATCH_FOUND;
     private boolean alsoCheckConsoleOutput;
 
     @Restricted(NoExternalUse.class)
@@ -80,6 +81,17 @@ public class TextFinder extends AbstractDescribableImpl<TextFinder> implements S
         }
 
         this.buildResult = buildResult;
+    }
+
+    @Restricted(NoExternalUse.class)
+    public TextFinderChangeCondition getChangeCondition() {
+        return changeCondition;
+    }
+
+    @DataBoundSetter
+    @Restricted(NoExternalUse.class)
+    public void setChangeCondition(TextFinderChangeCondition changeCondition) {
+        this.changeCondition = changeCondition;
     }
 
     @Restricted(NoExternalUse.class)

--- a/src/main/java/hudson/plugins/textfinder/TextFinderChangeCondition.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderChangeCondition.java
@@ -1,0 +1,25 @@
+package hudson.plugins.textfinder;
+
+import hudson.util.EnumConverter;
+
+import org.kohsuke.stapler.Stapler;
+
+public enum TextFinderChangeCondition {
+    MATCH_FOUND("Change the build result if a match is found"),
+    MATCH_NOT_FOUND("Change the build result if a match is not found");
+
+    private final String description;
+
+    TextFinderChangeCondition(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    static {
+        // Allow conversion from a string to an enumeration in the databinding process.
+        Stapler.CONVERT_UTILS.register(new EnumConverter(), TextFinderChangeCondition.class);
+    }
+}

--- a/src/main/resources/hudson/plugins/textfinder/TextFinder/config.jelly
+++ b/src/main/resources/hudson/plugins/textfinder/TextFinder/config.jelly
@@ -6,11 +6,13 @@
   <f:entry field="fileSet" title="${%Files}">
     <f:textbox/>
   </f:entry>
-  <f:entry field="alsoCheckConsoleOutput" title="">
-    <f:checkbox/>
-    <label class="attach-previous">${%Also search the console output}</label>
+  <f:entry field="alsoCheckConsoleOutput">
+    <f:checkbox title="${%Also search the console output}"/>
   </f:entry>
-  <f:entry field="buildResult" title="${%Build result if match found}">
+  <f:entry field="buildResult" title="${%Build result}">
     <f:select default="FAILURE"/>
+  </f:entry>
+  <f:entry title="${%Change condition}" field="changeCondition">
+    <f:enum field="changeCondition">${it.description}</f:enum>
   </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/textfinder/TextFinder/help-buildResult.html
+++ b/src/main/resources/hudson/plugins/textfinder/TextFinder/help-buildResult.html
@@ -1,7 +1,7 @@
 <div>
-    If a match is found, the build result will be set to this value. Note that
-    the build result can only get worse, so you cannot change the result to
-    <code>SUCCESS</code> if the current result is <code>UNSTABLE</code> or
-    worse. Use <code>SUCCESS</code> to keep the build result from being set when
-    a match is found.
+    Based on the change condition, the build result will be set to this value.
+    Note that the build result can only get worse, so you cannot change the
+    result to <code>SUCCESS</code> if the current result is
+    <code>UNSTABLE</code> or worse. Use <code>SUCCESS</code> to keep the build
+    result from being set.
 </div>

--- a/src/main/resources/hudson/plugins/textfinder/TextFinder/help-changeCondition.html
+++ b/src/main/resources/hudson/plugins/textfinder/TextFinder/help-changeCondition.html
@@ -1,0 +1,6 @@
+ <div>
+     If the change condition is <code>MATCH_FOUND</code>, then the build result
+     will be set if a match is found. If the change condition is
+     <code>MATCH_NOT_FOUND</code>, then the build result will be set if a match
+     is not found.
+ </div>

--- a/src/main/webapp/help.html
+++ b/src/main/webapp/help.html
@@ -1,11 +1,9 @@
 <div>
   <p>
     This plugin lets you search for some text using regular expressions in a set
-    of files or the console log. Once a match is found, you can downgrade the
+    of files or the console log. Based on the outcome, you can downgrade the
     build result to <code>UNSTABLE</code>, <code>FAILURE</code>,
-    <code>NOT_BUILT</code>, or <code>ABORTED</code>. See the Jenkins
-    <a href="https://javadoc.jenkins-ci.org/hudson/model/Result.html"><code>Result</code></a>
-    class for details.
+    <code>NOT_BUILT</code>, or <code>ABORTED</code>.
   </p>
   <p>
     For example, you can search for the string <code>failure</code> in a set of

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleCompatibilityTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleCompatibilityTest.java
@@ -148,7 +148,7 @@ public class TextFinderPublisherFreestyleCompatibilityTest {
     }
 
     @Test
-    public void notFoundInFile() throws Exception {
+    public void successIfNotFoundInFile() throws Exception {
         FreeStyleProject project = rule.createFreeStyleProject();
         project.getBuildersList().add(new TestWriteFileBuilder(TestUtils.FILE_SET, "foobaz"));
         TextFinderPublisher textFinder = new TextFinderPublisher(TestUtils.UNIQUE_TEXT);
@@ -169,6 +169,32 @@ public class TextFinderPublisherFreestyleCompatibilityTest {
                         + TestUtils.FILE_SET
                         + "'.",
                 build);
+    }
+
+    @Test
+    public void failureIfNotFoundInFile() throws Exception {
+        FreeStyleProject project = rule.createFreeStyleProject();
+        project.getBuildersList().add(new TestWriteFileBuilder(TestUtils.FILE_SET, "foobaz"));
+        TextFinderPublisher textFinder = new TextFinderPublisher(TestUtils.UNIQUE_TEXT);
+        textFinder.setFileSet(TestUtils.FILE_SET);
+        textFinder.setSucceedIfFound(true);
+        project.getPublishersList().add(textFinder);
+        FreeStyleBuild build = rule.buildAndAssertStatus(Result.FAILURE, project);
+        rule.assertLogContains(
+                "[Text Finder] Searching for pattern '"
+                        + TestUtils.UNIQUE_TEXT
+                        + "' in file set '"
+                        + TestUtils.FILE_SET
+                        + "'.",
+                build);
+        rule.assertLogContains(
+                "[Text Finder] Finished searching for pattern '"
+                        + TestUtils.UNIQUE_TEXT
+                        + "' in file set '"
+                        + TestUtils.FILE_SET
+                        + "'.",
+                build);
+        rule.assertLogContains("Setting build result to 'FAILURE'.", build);
     }
 
     @Test
@@ -238,7 +264,7 @@ public class TextFinderPublisherFreestyleCompatibilityTest {
     }
 
     @Test
-    public void notFoundInConsole() throws Exception {
+    public void successIfNotFoundInConsole() throws Exception {
         FreeStyleProject project = rule.createFreeStyleProject();
         TextFinderPublisher textFinder = new TextFinderPublisher(TestUtils.UNIQUE_TEXT);
         textFinder.setAlsoCheckConsoleOutput(true);
@@ -248,6 +274,21 @@ public class TextFinderPublisherFreestyleCompatibilityTest {
         rule.assertLogContains(
                 "Finished searching for pattern '" + TestUtils.UNIQUE_TEXT + "' in console output.",
                 build);
+    }
+
+    @Test
+    public void failureIfNotFoundInConsole() throws Exception {
+        FreeStyleProject project = rule.createFreeStyleProject();
+        TextFinderPublisher textFinder = new TextFinderPublisher(TestUtils.UNIQUE_TEXT);
+        textFinder.setAlsoCheckConsoleOutput(true);
+        textFinder.setSucceedIfFound(true);
+        project.getPublishersList().add(textFinder);
+        FreeStyleBuild build = rule.buildAndAssertStatus(Result.FAILURE, project);
+        rule.assertLogContains("[Text Finder] Searching console output...", build);
+        rule.assertLogContains(
+                "Finished searching for pattern '" + TestUtils.UNIQUE_TEXT + "' in console output.",
+                build);
+        rule.assertLogContains("Setting build result to 'FAILURE'.", build);
     }
 
     @LocalData

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleJobDslTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleJobDslTest.java
@@ -345,7 +345,7 @@ public class TextFinderPublisherFreestyleJobDslTest {
     }
 
     @Test
-    public void notFoundInFile() throws Exception {
+    public void successIfNotFoundInFile() throws Exception {
         FreeStyleProject project =
                 createProjectFromDsl(
                         "  steps {\n"
@@ -385,6 +385,51 @@ public class TextFinderPublisherFreestyleJobDslTest {
                         + TestUtils.FILE_SET
                         + "'.",
                 build);
+    }
+
+    @Test
+    public void failureIfNotFoundInFile() throws Exception {
+        FreeStyleProject project =
+                createProjectFromDsl(
+                        "  steps {\n"
+                                + "    testWriteFileBuilder {\n"
+                                + "      file '"
+                                + TestUtils.FILE_SET
+                                + "'\n"
+                                + "      text 'foobaz'\n"
+                                + "    }\n"
+                                + "  }\n"
+                                + "  publishers {\n"
+                                + "    findText {\n"
+                                + "      textFinders {\n"
+                                + "        textFinder {\n"
+                                + "          regexp '"
+                                + TestUtils.UNIQUE_TEXT
+                                + "'\n"
+                                + "      fileSet '"
+                                + TestUtils.FILE_SET
+                                + "'\n"
+                                + "      changeCondition 'MATCH_NOT_FOUND'\n"
+                                + "        }\n"
+                                + "      }\n"
+                                + "    }\n"
+                                + "  }\n");
+        FreeStyleBuild build = rule.buildAndAssertStatus(Result.FAILURE, project);
+        rule.assertLogContains(
+                "[Text Finder] Searching for pattern '"
+                        + TestUtils.UNIQUE_TEXT
+                        + "' in file set '"
+                        + TestUtils.FILE_SET
+                        + "'.",
+                build);
+        rule.assertLogContains(
+                "[Text Finder] Finished searching for pattern '"
+                        + TestUtils.UNIQUE_TEXT
+                        + "' in file set '"
+                        + TestUtils.FILE_SET
+                        + "'.",
+                build);
+        rule.assertLogContains("Setting build result to 'FAILURE'.", build);
     }
 
     @Test
@@ -551,7 +596,7 @@ public class TextFinderPublisherFreestyleJobDslTest {
     }
 
     @Test
-    public void notFoundInConsole() throws Exception {
+    public void successIfNotFoundInConsole() throws Exception {
         FreeStyleProject project =
                 createProjectFromDsl(
                         "  publishers {\n"
@@ -571,6 +616,31 @@ public class TextFinderPublisherFreestyleJobDslTest {
         rule.assertLogContains(
                 "Finished searching for pattern '" + TestUtils.UNIQUE_TEXT + "' in console output.",
                 build);
+    }
+
+    @Test
+    public void failureIfNotFoundInConsole() throws Exception {
+        FreeStyleProject project =
+                createProjectFromDsl(
+                        "  publishers {\n"
+                                + "    findText {\n"
+                                + "      textFinders {\n"
+                                + "        textFinder {\n"
+                                + "          regexp '"
+                                + TestUtils.UNIQUE_TEXT
+                                + "'\n"
+                                + "      alsoCheckConsoleOutput true\n"
+                                + "      changeCondition 'MATCH_NOT_FOUND'\n"
+                                + "        }\n"
+                                + "      }\n"
+                                + "    }\n"
+                                + "  }\n");
+        FreeStyleBuild build = rule.buildAndAssertStatus(Result.FAILURE, project);
+        rule.assertLogContains("[Text Finder] Searching console output...", build);
+        rule.assertLogContains(
+                "Finished searching for pattern '" + TestUtils.UNIQUE_TEXT + "' in console output.",
+                build);
+        rule.assertLogContains("Setting build result to 'FAILURE'.", build);
     }
 
     @Test

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
@@ -194,7 +194,7 @@ public class TextFinderPublisherFreestyleTest {
     }
 
     @Test
-    public void notFoundInFile() throws Exception {
+    public void successIfNotFoundInFile() throws Exception {
         FreeStyleProject project = rule.createFreeStyleProject();
         project.getBuildersList().add(new TestWriteFileBuilder(TestUtils.FILE_SET, "foobaz"));
         TextFinder textFinder = new TextFinder(TestUtils.UNIQUE_TEXT);
@@ -217,6 +217,34 @@ public class TextFinderPublisherFreestyleTest {
                         + TestUtils.FILE_SET
                         + "'.",
                 build);
+    }
+
+    @Test
+    public void failureIfNotFoundInFile() throws Exception {
+        FreeStyleProject project = rule.createFreeStyleProject();
+        project.getBuildersList().add(new TestWriteFileBuilder(TestUtils.FILE_SET, "foobaz"));
+        TextFinder textFinder = new TextFinder(TestUtils.UNIQUE_TEXT);
+        textFinder.setFileSet(TestUtils.FILE_SET);
+        textFinder.setChangeCondition(TextFinderChangeCondition.MATCH_NOT_FOUND);
+        TextFinderPublisher textFinderPublisher = new TextFinderPublisher();
+        textFinderPublisher.setTextFinders(Collections.singletonList(textFinder));
+        project.getPublishersList().add(textFinderPublisher);
+        FreeStyleBuild build = rule.buildAndAssertStatus(Result.FAILURE, project);
+        rule.assertLogContains(
+                "[Text Finder] Searching for pattern '"
+                        + TestUtils.UNIQUE_TEXT
+                        + "' in file set '"
+                        + TestUtils.FILE_SET
+                        + "'.",
+                build);
+        rule.assertLogContains(
+                "[Text Finder] Finished searching for pattern '"
+                        + TestUtils.UNIQUE_TEXT
+                        + "' in file set '"
+                        + TestUtils.FILE_SET
+                        + "'.",
+                build);
+        rule.assertLogContains("Setting build result to 'FAILURE'.", build);
     }
 
     @Test
@@ -353,7 +381,7 @@ public class TextFinderPublisherFreestyleTest {
     }
 
     @Test
-    public void notFoundInConsole() throws Exception {
+    public void successIfNotFoundInConsole() throws Exception {
         FreeStyleProject project = rule.createFreeStyleProject();
         TextFinder textFinder = new TextFinder(TestUtils.UNIQUE_TEXT);
         textFinder.setAlsoCheckConsoleOutput(true);
@@ -365,6 +393,23 @@ public class TextFinderPublisherFreestyleTest {
         rule.assertLogContains(
                 "Finished searching for pattern '" + TestUtils.UNIQUE_TEXT + "' in console output.",
                 build);
+    }
+
+    @Test
+    public void failureIfNotFoundInConsole() throws Exception {
+        FreeStyleProject project = rule.createFreeStyleProject();
+        TextFinder textFinder = new TextFinder(TestUtils.UNIQUE_TEXT);
+        textFinder.setAlsoCheckConsoleOutput(true);
+        textFinder.setChangeCondition(TextFinderChangeCondition.MATCH_NOT_FOUND);
+        TextFinderPublisher textFinderPublisher = new TextFinderPublisher();
+        textFinderPublisher.setTextFinders(Collections.singletonList(textFinder));
+        project.getPublishersList().add(textFinderPublisher);
+        FreeStyleBuild build = rule.buildAndAssertStatus(Result.FAILURE, project);
+        rule.assertLogContains("[Text Finder] Searching console output...", build);
+        rule.assertLogContains(
+                "Finished searching for pattern '" + TestUtils.UNIQUE_TEXT + "' in console output.",
+                build);
+        rule.assertLogContains("Setting build result to 'FAILURE'.", build);
     }
 
     @Test


### PR DESCRIPTION
See [JENKINS-62734](https://issues.jenkins-ci.org/browse/JENKINS-62734). @MarkEWaite noticed that the new Text Finder API released in 1.13 no longer supports some use cases that the old API supported (albeit in an unintuitive way). This PR adds a `changeCondition` feature to the new API which restores feature parity with the old API and adjusts the migration logic to appropriately migrate any relevant use cases to the new API. I haven't written automated tests yet, but I will before merging this PR.