### PR TITLE
Dependency updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -7,12 +7,3 @@ update_configs:
     - "basil"
   default_assignees:
     - "basil"
-  ignored_updates:
-    - match:
-        dependency_name: "org.jenkins-ci.main:jenkins-core"
-    - match:
-        dependency_name: "org.jenkins-ci:symbol-annotation"
-    - match:
-        dependency_name: "org.jenkins-ci.plugins*"
-    - match:
-        dependency_name: "io.jenkins.plugins*"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,9 +4,9 @@ buildPlugin(configurations: [
   [ platform: 'linux', jdk: '8', jenkins: null ],
 
   // Test the common case (i.e., a recent LTS release) on both Linux and Windows.
-  [ platform: 'linux', jdk: '8', jenkins: '2.222.4', javaLevel: '8' ],
-  [ platform: 'windows', jdk: '8', jenkins: '2.222.4', javaLevel: '8' ],
+  [ platform: 'linux', jdk: '8', jenkins: '2.235.1', javaLevel: '8' ],
+  [ platform: 'windows', jdk: '8', jenkins: '2.235.1', javaLevel: '8' ],
 
   // Test the bleeding edge of the compatibility spectrum (i.e., the latest supported Java runtime).
-  [ platform: 'linux', jdk: '11', jenkins: '2.222.4', javaLevel: '8' ],
+  [ platform: 'linux', jdk: '11', jenkins: '2.235.1', javaLevel: '8' ],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.2</version>
+        <version>4.3</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
This change performs a number of dependency updates:

- Updates the plugin POM to the latest version
- Updates the LTS version used in CI testing to the latest LTS release
- Removes the exclusions from the Dependabot configuration, which are no longer necessary now that we have adopted the BOM