### PR TITLE
[JENKINS-63046] NullPointerException in TextFinderPublisher#findText when upgrading from 1.13

### DIFF
--- a/src/main/java/hudson/plugins/textfinder/TextFinder.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinder.java
@@ -105,6 +105,19 @@ public class TextFinder extends AbstractDescribableImpl<TextFinder> implements S
         this.alsoCheckConsoleOutput = alsoCheckConsoleOutput;
     }
 
+    /**
+     * Called by XStream after object construction
+     *
+     * @return modified object
+     */
+    protected Object readResolve() {
+        if (changeCondition == null) {
+            changeCondition = TextFinderChangeCondition.MATCH_FOUND;
+        }
+
+        return this;
+    }
+
     @Symbol("textFinder")
     @Extension
     public static class DescriptorImpl extends Descriptor<TextFinder> {

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleCompatibilityTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleCompatibilityTest.java
@@ -1,6 +1,7 @@
 package hudson.plugins.textfinder;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import hudson.model.FreeStyleBuild;
@@ -312,5 +313,29 @@ public class TextFinderPublisherFreestyleCompatibilityTest {
         assertEquals("out.txt", textFinder.getFileSet());
         assertEquals(Result.UNSTABLE.toString(), textFinder.getBuildResult());
         assertTrue(textFinder.isAlsoCheckConsoleOutput());
+    }
+
+    @LocalData
+    @Test
+    public void persistedConfigurationBeforeChangeCondition() throws Exception {
+        // Local data created using Text Finder 1.13 with the following code:
+        /*
+        FreeStyleProject project = rule.createFreeStyleProject();
+        project.getBuildersList()
+                .add(new TestWriteFileBuilder(TestUtils.FILE_SET, TestUtils.UNIQUE_TEXT));
+        TextFinderPublisher textFinder = new TextFinderPublisher(TestUtils.UNIQUE_TEXT);
+        textFinder.setFileSet(TestUtils.FILE_SET);
+        project.getPublishersList().add(textFinder);
+        */
+        FreeStyleProject project = rule.jenkins.getItemByFullName("test0", FreeStyleProject.class);
+        assertEquals(1, project.getPublishersList().size());
+        TextFinderPublisher textFinderPublisher =
+                (TextFinderPublisher) project.getPublishersList().get(0);
+        TextFinder textFinder = textFinderPublisher.getTextFinders().get(0);
+        assertEquals(TestUtils.UNIQUE_TEXT, textFinder.getRegexp());
+        assertEquals(TestUtils.FILE_SET, textFinder.getFileSet());
+        assertEquals(Result.FAILURE.toString(), textFinder.getBuildResult());
+        assertEquals(TextFinderChangeCondition.MATCH_FOUND, textFinder.getChangeCondition());
+        assertFalse(textFinder.isAlsoCheckConsoleOutput());
     }
 }

--- a/src/test/resources/hudson/plugins/textfinder/TextFinderPublisherFreestyleCompatibilityTest/persistedConfigurationBeforeChangeCondition/jobs/test0/config.xml
+++ b/src/test/resources/hudson/plugins/textfinder/TextFinderPublisherFreestyleCompatibilityTest/persistedConfigurationBeforeChangeCondition/jobs/test0/config.xml
@@ -1,0 +1,26 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<project>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders/>
+  <publishers>
+    <hudson.plugins.textfinder.TextFinderPublisher>
+      <textFinders>
+        <hudson.plugins.textfinder.TextFinder>
+          <regexp>foobar</regexp>
+          <fileSet>out.txt</fileSet>
+          <buildResult>FAILURE</buildResult>
+          <alsoCheckConsoleOutput>false</alsoCheckConsoleOutput>
+        </hudson.plugins.textfinder.TextFinder>
+      </textFinders>
+    </hudson.plugins.textfinder.TextFinderPublisher>
+  </publishers>
+  <buildWrappers/>
+</project>


### PR DESCRIPTION
Persisted configuration from Text Finder 1.13 did not have the new change condition field introduced in 1.14. Fixed this by adding a `readResolve` method that sets the field if it is unset.