### PR TITLE
Test with config file provider plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,11 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>config-file-provider</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>job-dsl</artifactId>
             <version>1.81</version>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <revision>1.21</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.289.1</jenkins.version>
+        <jenkins.version>2.332.4</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
 
@@ -52,8 +52,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.289.x</artifactId>
-                <version>1500.ve4d05cd32975</version>
+                <artifactId>bom-2.332.x</artifactId>
+                <version>1678.vc1feb_6a_3c0f1</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
## Test with config file provider plugin

- Require Jenkins 2.332.4 or newer
- Declare config file provider test dependency

Declare config file provider test dependency

Tests run successfully fine without this dependency when executed from the usual Apache Maven command line as in:

$ `mvn clean verify`

Tests fail when run in the BOM evaluation.  They report that a class from the config file provider plugin could not be found.

https://github.com/jenkinsci/bom/pull/1435#issuecomment-1314102830 provides details.

Also increments minimum Jenkins version to 2.332.4 in order to reduce maintenance burden.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
