### PR TITLE
Suppress warnings for spotbugs 4.8.3

### DIFF
--- a/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
@@ -1,6 +1,7 @@
 package hudson.plugins.textfinder;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Functions;
@@ -57,27 +58,33 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
 
     @Deprecated
     @Restricted(NoExternalUse.class)
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility.")
     public transient String fileSet;
 
     @Deprecated
     @Restricted(NoExternalUse.class)
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility.")
     public transient String regexp;
 
     @Deprecated
     @Restricted(NoExternalUse.class)
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility.")
     public transient boolean succeedIfFound;
 
     @Deprecated
     @Restricted(NoExternalUse.class)
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility.")
     public transient boolean unstableIfFound;
 
     @Deprecated
     @Restricted(NoExternalUse.class)
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility.")
     public transient boolean notBuiltIfFound;
 
     /** True to also scan the whole console output */
     @Deprecated
     @Restricted(NoExternalUse.class)
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility.")
     public transient boolean alsoCheckConsoleOutput;
 
     /** Used only by Stapler in the snippetizer. */


### PR DESCRIPTION
## Suppress warnings for spotbugs 4.8.3

https://github.com/jenkinsci/plugin-pom/pull/869 or a subsequent pull request that updates to 4.8.3 will need this change in the plugin to resolve new spotbugs warnings that will be reported by spotbugs 4.8.2 and later.

Plugin pom 4.77 is likely to include that new version of spotbugs.

### Testing done

Confirmed that the spotbugs warnings are visible when using the 4.77-SNAPSHOT plugin pom before this change. With this change, the spotbugs warnings are no longer visible.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
```
