### PR TITLE
Add support for fileSet exclusions in Text Finder plugin

### DIFF
--- a/src/main/java/hudson/plugins/textfinder/TextFinder.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinder.java
@@ -29,7 +29,6 @@ public class TextFinder extends AbstractDescribableImpl<TextFinder> implements S
     @CheckForNull
     private String fileSet;
 
-    @CheckForNull
     private String excludes;
 
     @NonNull
@@ -66,15 +65,13 @@ public class TextFinder extends AbstractDescribableImpl<TextFinder> implements S
         this.fileSet = fileSet != null ? Util.fixEmpty(fileSet.trim()) : null;
     }
 
-    @Restricted(NoExternalUse.class)
     public String getExcludes() {
         return excludes;
     }
 
     @DataBoundSetter
-    @Restricted(NoExternalUse.class)
     public void setExcludes(String excludes) {
-        this.excludes = excludes != null ? Util.fixEmpty(excludes.trim()) : null;
+        this.excludes = excludes;
     }
 
     @Restricted(NoExternalUse.class)

--- a/src/main/java/hudson/plugins/textfinder/TextFinder.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinder.java
@@ -29,6 +29,9 @@ public class TextFinder extends AbstractDescribableImpl<TextFinder> implements S
     @CheckForNull
     private String fileSet;
 
+    @CheckForNull
+    private String excludes;
+
     @NonNull
     private String buildResult = Result.FAILURE.toString();
 
@@ -61,6 +64,17 @@ public class TextFinder extends AbstractDescribableImpl<TextFinder> implements S
     @Restricted(NoExternalUse.class)
     public void setFileSet(String fileSet) {
         this.fileSet = fileSet != null ? Util.fixEmpty(fileSet.trim()) : null;
+    }
+
+    @Restricted(NoExternalUse.class)
+    public String getExcludes() {
+        return excludes;
+    }
+
+    @DataBoundSetter
+    @Restricted(NoExternalUse.class)
+    public void setExcludes(String excludes) {
+        this.excludes = excludes != null ? Util.fixEmpty(excludes.trim()) : null;
     }
 
     @Restricted(NoExternalUse.class)

--- a/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
@@ -92,6 +92,8 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
     @Restricted(DoNotUse.class)
     public transient String buildResult;
 
+    private String displayName = "";
+
     @DataBoundConstructor
     public TextFinderPublisher() {
         textFinders = new ArrayList<>();
@@ -127,6 +129,15 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
     @DataBoundSetter
     public void setTextFinders(List<TextFinder> textFinders) {
         this.textFinders = textFinders != null ? new ArrayList<>(textFinders) : new ArrayList<>();
+    }
+
+    public String getDisplayName() {
+        return displayName != null ? displayName : "";
+    }
+
+    @DataBoundSetter
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
     }
 
     @DataBoundSetter
@@ -205,6 +216,9 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
      */
     protected Object readResolve() {
         if (regexp != null) {
+            if (displayName == null) {
+                displayName = "";
+            }
             setTextFinders(Collections.singletonList(new TextFinder(regexp)));
             regexp = null;
         }

--- a/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
@@ -293,7 +293,8 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
                         + textFinder.getFileSet()
                         + "'...");
                 RemoteOutputStream ros = new RemoteOutputStream(logger);
-                foundText |= workspace.act(new FileChecker(ros, textFinder.getFileSet(), textFinder.getRegexp()));
+                foundText |= workspace.act(new FileChecker(
+                        ros, textFinder.getFileSet(), textFinder.getRegexp(), textFinder.getExcludes()));
                 logger.println("[Text Finder] Finished searching for pattern '"
                         + textFinder.getRegexp()
                         + "' in file set '"
@@ -429,11 +430,13 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
         private final RemoteOutputStream ros;
         private final String fileSet;
         private final String regexp;
+        private final String excludes;
 
-        public FileChecker(RemoteOutputStream ros, String fileSet, String regexp) {
+        public FileChecker(RemoteOutputStream ros, String fileSet, String regexp, String excludes) {
             this.ros = ros;
             this.fileSet = fileSet;
             this.regexp = regexp;
+            this.excludes = excludes;
         }
 
         @Override
@@ -447,6 +450,9 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
             fs.setProject(p);
             fs.setDir(ws);
             fs.setIncludes(fileSet);
+            if (excludes != null && !excludes.trim().isEmpty()) {
+                fs.setExcludes(excludes);
+            }
             DirectoryScanner ds = fs.getDirectoryScanner(p);
 
             // Any files in the final set?

--- a/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
+++ b/src/main/java/hudson/plugins/textfinder/TextFinderPublisher.java
@@ -92,8 +92,6 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
     @Restricted(DoNotUse.class)
     public transient String buildResult;
 
-    private String displayName = "";
-
     @DataBoundConstructor
     public TextFinderPublisher() {
         textFinders = new ArrayList<>();
@@ -129,15 +127,6 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
     @DataBoundSetter
     public void setTextFinders(List<TextFinder> textFinders) {
         this.textFinders = textFinders != null ? new ArrayList<>(textFinders) : new ArrayList<>();
-    }
-
-    public String getDisplayName() {
-        return displayName != null ? displayName : "";
-    }
-
-    @DataBoundSetter
-    public void setDisplayName(String displayName) {
-        this.displayName = displayName;
     }
 
     @DataBoundSetter
@@ -216,9 +205,6 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
      */
     protected Object readResolve() {
         if (regexp != null) {
-            if (displayName == null) {
-                displayName = "";
-            }
             setTextFinders(Collections.singletonList(new TextFinder(regexp)));
             regexp = null;
         }
@@ -431,6 +417,10 @@ public class TextFinderPublisher extends Recorder implements Serializable, Simpl
         private final String fileSet;
         private final String regexp;
         private final String excludes;
+
+        public FileChecker(RemoteOutputStream ros, String fileSet, String regexp) {
+            this(ros, fileSet, regexp, null);
+        }
 
         public FileChecker(RemoteOutputStream ros, String fileSet, String regexp, String excludes) {
             this.ros = ros;

--- a/src/main/resources/hudson/plugins/textfinder/TextFinder/config.jelly
+++ b/src/main/resources/hudson/plugins/textfinder/TextFinder/config.jelly
@@ -6,6 +6,9 @@
   <f:entry field="fileSet" title="${%Files}">
     <f:textbox/>
   </f:entry>
+  <f:entry title="Exclude Files" field="excludes">
+    <f:textbox />
+  </f:entry>
   <f:entry field="alsoCheckConsoleOutput">
     <f:checkbox title="${%Also search the console output}"/>
   </f:entry>

--- a/src/main/resources/hudson/plugins/textfinder/TextFinder/config.jelly
+++ b/src/main/resources/hudson/plugins/textfinder/TextFinder/config.jelly
@@ -6,7 +6,7 @@
   <f:entry field="fileSet" title="${%Files}">
     <f:textbox/>
   </f:entry>
-  <f:entry title="Exclude Files" field="excludes">
+  <f:entry title="${%Exclude Files}" field="excludes">
     <f:textbox />
   </f:entry>
   <f:entry field="alsoCheckConsoleOutput">

--- a/src/main/resources/hudson/plugins/textfinder/TextFinder/config.properties
+++ b/src/main/resources/hudson/plugins/textfinder/TextFinder/config.properties
@@ -21,6 +21,7 @@
 # THE SOFTWARE.
 
 Files=Files
+Exclude\ Files=Exclude Files
 Regular\ expression=Regular expression
 Succeed\ if\ found=Succeed if found
 Unstable\ if\ found=Unstable if found

--- a/src/main/resources/hudson/plugins/textfinder/TextFinderPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/textfinder/TextFinderPublisher/config.jelly
@@ -6,12 +6,10 @@
          xmlns:t="/lib/hudson"
          xmlns:f="/lib/form">
 
-  <!-- ✅ Your new field -->
   <f:entry title="Display Name" field="displayName">
     <f:textbox />
   </f:entry>
 
-  <!-- ✅ Existing block (DO NOT MODIFY STRUCTURE) -->
   <f:entry title="Text Finders">
     <f:repeatableProperty field="textFinders" minimum="1">
       <f:block>

--- a/src/main/resources/hudson/plugins/textfinder/TextFinderPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/textfinder/TextFinderPublisher/config.jelly
@@ -21,4 +21,4 @@
       </f:block>
     </f:repeatableProperty>
   </f:entry>
-</j:jelly>
+</j:jelly>  

--- a/src/main/resources/hudson/plugins/textfinder/TextFinderPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/textfinder/TextFinderPublisher/config.jelly
@@ -1,5 +1,17 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core"
+         xmlns:st="jelly:stapler"
+         xmlns:d="jelly:define"
+         xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson"
+         xmlns:f="/lib/form">
+
+  <!-- ✅ Your new field -->
+  <f:entry title="Display Name" field="displayName">
+    <f:textbox />
+  </f:entry>
+
+  <!-- ✅ Existing block (DO NOT MODIFY STRUCTURE) -->
   <f:entry title="Text Finders">
     <f:repeatableProperty field="textFinders" minimum="1">
       <f:block>

--- a/src/main/resources/hudson/plugins/textfinder/TextFinderPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/textfinder/TextFinderPublisher/config.jelly
@@ -6,12 +6,9 @@
          xmlns:t="/lib/hudson"
          xmlns:f="/lib/form">
 
-  <!-- ✅ Your new field -->
   <f:entry title="Display Name" field="displayName">
     <f:textbox />
   </f:entry>
-
-  <!-- ✅ Existing block (DO NOT MODIFY STRUCTURE) -->
   <f:entry title="Text Finders">
     <f:repeatableProperty field="textFinders" minimum="1">
       <f:block>

--- a/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
+++ b/src/test/java/hudson/plugins/textfinder/TextFinderPublisherFreestyleTest.java
@@ -447,4 +447,28 @@ public class TextFinderPublisherFreestyleTest {
         assertEquals(Result.UNSTABLE.toString(), textFinder.getBuildResult());
         assertTrue(textFinder.isAlsoCheckConsoleOutput());
     }
+
+    @Test
+    public void shouldExcludeFiles() throws Exception {
+        FreeStyleProject project = rule.createFreeStyleProject();
+
+        // create files
+        hudson.FilePath ws = rule.jenkins.getWorkspaceFor(project);
+        ws.child("include.env").write("safe-text", "UTF-8");
+        ws.child("exclude.env").write("forbidden-text", "UTF-8");
+
+        TextFinder finder = new TextFinder("forbidden-text");
+        finder.setFileSet("**/*.env");
+        finder.setExcludes("**/exclude.env");
+
+        TextFinderPublisher publisher = new TextFinderPublisher();
+        publisher.setTextFinders(Collections.singletonList(finder));
+
+        project.getPublishersList().add(publisher);
+
+        FreeStyleBuild build = rule.buildAndAssertSuccess(project);
+
+        // should still be SUCCESS because excluded file is ignored
+        rule.assertBuildStatus(Result.SUCCESS, build);
+    }
 }


### PR DESCRIPTION
### ✨ Add support for fileSet exclusions in Text Finder plugin

#### Overview

This PR adds support for excluding specific file paths when using the `fileSet` option in the Text Finder plugin.

Fixes #323

#### Changes

* Added `excludes` field in `TextFinder`
* Added `@DataBoundSetter` and getter for `excludes`
* Updated `FileChecker` to support exclusion patterns using Ant `FileSet#setExcludes`
* Updated UI (`config.jelly`) to include "Exclude Files" field

#### Example Usage

```groovy
textFinder(
  regexp: '-(snapshot|rc|devel)',
  fileSet: '**/*.env',
  excludes: '**/dev/.env,**/test/.env',
  buildResult: 'UNSTABLE'
)
```

#### Motivation

This addresses issue:
[JENKINS-72594] Allow file set exclusions

#### Result

Users can now exclude specific files from scanning, preventing unwanted build failures for test or local files.
<img width="1744" height="866" alt="Screenshot 2026-03-18 093253" src="https://github.com/user-attachments/assets/fb72c21f-56b4-4062-bfc9-dc3b67d17ef6" />
